### PR TITLE
🔒 [security fix] Add missing exclusions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,25 @@ gradle-app.setting
 
 # Application Log
 *.log
+
+# IDEs
+.idea/
+.vscode/
+*.iml
+*.ipr
+*.iws
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Secrets
+.env
+*.pem
+*.key
+*.jks
+*.p12
+id_rsa
+id_dsa
+secrets.properties
+credentials.json


### PR DESCRIPTION
* 🎯 **What:** Updated `.gitignore` to include standard exclusions for secrets, IDE configuration files, and OS files.
* ⚠️ **Risk:** Without these exclusions, sensitive files like `.env`, private keys, and IDE settings could be accidentally committed, exposing credentials and cluttering the repository.
* 🛡️ **Solution:** Added patterns for `.env`, `*.pem`, `*.key`, `*.jks`, `.idea/`, `.vscode/`, `.DS_Store`, and others.

---
*PR created automatically by Jules for task [16885950105791083786](https://jules.google.com/task/16885950105791083786) started by @dclements*