### PR TITLE
Fix: Remove insecure protocols from Checkstyle LineLength ignore pattern

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -16,7 +16,7 @@
   <module name="LineLength">
     <property name="max" value="100"/>
     <property name="ignorePattern"
-             value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
+             value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|https://"/>
   </module>
   <module name="NewlineAtEndOfFile"/>
   <module name="TreeWalker">


### PR DESCRIPTION
Removed `http://` and `ftp://` from the `LineLength` check's `ignorePattern` in `config/checkstyle/checkstyle.xml`.
This ensures that long lines containing insecure URLs are flagged, encouraging the use of secure protocols like `https://`.

This change addresses a security vulnerability where insecure protocols were explicitly allowed to exceed the line length limit, potentially hiding them or encouraging their use.

---
*PR created automatically by Jules for task [13102038224016827482](https://jules.google.com/task/13102038224016827482) started by @dclements*