### PR TITLE
Enforce dependency constraints for commons-beanutils, log4j-core, and commons-lang3

### DIFF
--- a/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
@@ -15,4 +15,15 @@ tasks.withType<JavaCompile>().configureEach {
 
 dependencies {
     api(getLibrary("slf4j-api"))
+    constraints {
+        implementation(getLibrary("commons-beanutils")) {
+            because("CVE-2025-48734")
+        }
+        implementation(getLibrary("log4j-core")) {
+            because("CVE-2025-68161")
+        }
+        implementation(getLibrary("commons-lang3")) {
+            because("CVE-2025-48924")
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,9 @@ assertj = "3.27.7"
 mockito = "5.21.0"
 cucumber = "7.34.2"
 jacoco = "0.8.14"
+beanutils = "1.11.0"
+log4j = "2.53.2"
+commons-lang3 = "3.18.0"
 
 [libraries]
 # Core
@@ -29,6 +32,9 @@ slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
 # Utilities
+commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "beanutils" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 guice = { module = "com.google.inject:guice", version.ref = "guice" }
 mug = { module = "com.google.mug:mug", version.ref = "mug" }


### PR DESCRIPTION
Enforces dependency constraints for `commons-beanutils`, `log4j-core`, and `commons-lang3` to mitigate CVEs by updating `gradle/libs.versions.toml` and applying constraints in `larpconnect.java-common`.

---
*PR created automatically by Jules for task [2793836880044717956](https://jules.google.com/task/2793836880044717956) started by @dclements*