### PR TITLE
Enable comprehensive quality checks and task ordering

### DIFF
--- a/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.spotbugs.snom.SpotBugsTask
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
@@ -61,6 +62,16 @@ tasks.withType<JacocoCoverageVerification>().configureEach {
             }
         }
     }
+}
+
+tasks.withType<Checkstyle>().configureEach {
+    shouldRunAfter("spotlessApply")
+    shouldRunAfter("spotlessJava")
+}
+
+tasks.withType<SpotBugsTask>().configureEach {
+    shouldRunAfter("spotlessApply")
+    shouldRunAfter("spotlessJava")
 }
 
 tasks.named("check") {


### PR DESCRIPTION
Updated `larpconnect.quality.gradle.kts` to import `SpotBugsTask` and configure `shouldRunAfter` dependencies for Checkstyle and Spotbugs on Spotless tasks. Verified that JacocoCoverageVerification depends on Test tasks. Validated build script compilation and task execution order.

---
*PR created automatically by Jules for task [17967632949573422605](https://jules.google.com/task/17967632949573422605) started by @dclements*