### PR TITLE
Invert dependency between :common and :parent modules

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    api(libs.guice)
+    api(project(":parent"))
 }

--- a/parent/build.gradle.kts
+++ b/parent/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     api(platform(project(":bom")))
-    api(project(":common"))
 
     api(libs.vertx.core)
     api(libs.guava)


### PR DESCRIPTION
Inverted the dependency relationship between the `:common` and `:parent` modules.
Now `:common` depends on `:parent`, and `:parent` no longer exports `:common`.
This aligns with the user request and standard architectural layering where a common module may build upon a base platform/parent module.
Verified by running dependency checks and a full build.

---
*PR created automatically by Jules for task [2531121152977149907](https://jules.google.com/task/2531121152977149907) started by @dclements*