### PR TITLE
Document deprecation suppression in GuiceVerticleFactory

### DIFF
--- a/init/src/main/java/com/larpconnect/njall/init/GuiceVerticleFactory.java
+++ b/init/src/main/java/com/larpconnect/njall/init/GuiceVerticleFactory.java
@@ -20,6 +20,9 @@ final class GuiceVerticleFactory implements VerticleFactory {
   }
 
   @Override
+  // createVerticle is deprecated in favor of createVerticle2 which supports Deployable.
+  // We are suppressing this warning as this factory specifically handles Verticles
+  // and has not been migrated to the new API yet.
   @SuppressWarnings("deprecation")
   public void createVerticle(
       String verticleName, ClassLoader classLoader, Promise<Callable<Verticle>> promise) {


### PR DESCRIPTION
Documented the reason for `@SuppressWarnings("deprecation")` in `GuiceVerticleFactory.java`.

The documentation clarifies that:
1. `createVerticle` is deprecated in Vert.x 5 in favor of `createVerticle2`.
2. The suppression is needed because the codebase has not yet migrated to the new `Deployable` API and still relies on `Verticle`.


---
*PR created automatically by Jules for task [10159316124538922006](https://jules.google.com/task/10159316124538922006) started by @dclements*