### PR TITLE
Upgrade GuiceVerticleFactory to Vert.x 5 API

### DIFF
--- a/init/src/main/java/com/larpconnect/njall/init/GuiceVerticleFactory.java
+++ b/init/src/main/java/com/larpconnect/njall/init/GuiceVerticleFactory.java
@@ -1,6 +1,7 @@
 package com.larpconnect.njall.init;
 
 import com.google.inject.Injector;
+import io.vertx.core.Deployable;
 import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.spi.VerticleFactory;
@@ -20,12 +21,10 @@ final class GuiceVerticleFactory implements VerticleFactory {
   }
 
   @Override
-  // createVerticle is deprecated in favor of createVerticle2 which supports Deployable.
-  // We are suppressing this warning as this factory specifically handles Verticles
-  // and has not been migrated to the new API yet.
-  @SuppressWarnings("deprecation")
-  public void createVerticle(
-      String verticleName, ClassLoader classLoader, Promise<Callable<Verticle>> promise) {
+  public void createVerticle2(
+      String verticleName,
+      ClassLoader classLoader,
+      Promise<Callable<? extends Deployable>> promise) {
     var clazzName = VerticleFactory.removePrefix(verticleName);
     promise.complete(
         () -> {

--- a/init/src/test/java/com/larpconnect/njall/init/GuiceVerticleFactoryTest.java
+++ b/init/src/test/java/com/larpconnect/njall/init/GuiceVerticleFactoryTest.java
@@ -7,8 +7,8 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Deployable;
 import io.vertx.core.Promise;
-import io.vertx.core.Verticle;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.Callable;
@@ -34,8 +34,8 @@ public class GuiceVerticleFactoryTest {
     GuiceVerticleFactory factory = new GuiceVerticleFactory(injector);
     assertThat(factory.prefix()).isEqualTo("guice");
 
-    Promise<Callable<Verticle>> promise = Promise.promise();
-    factory.createVerticle(
+    Promise<Callable<? extends Deployable>> promise = Promise.promise();
+    factory.createVerticle2(
         "guice:" + TestVerticle.class.getName(), getClass().getClassLoader(), promise);
 
     promise
@@ -44,7 +44,7 @@ public class GuiceVerticleFactoryTest {
             testContext.succeeding(
                 callable -> {
                   try {
-                    Verticle verticle = callable.call();
+                    Deployable verticle = callable.call();
                     assertThat(verticle).isInstanceOf(TestVerticle.class);
                     testContext.completeNow();
                   } catch (Exception e) { // Callable throws Exception
@@ -58,8 +58,8 @@ public class GuiceVerticleFactoryTest {
     Injector injector = Guice.createInjector();
     GuiceVerticleFactory factory = new GuiceVerticleFactory(injector);
 
-    Promise<Callable<Verticle>> promise = Promise.promise();
-    factory.createVerticle("guice:com.example.MissingClass", getClass().getClassLoader(), promise);
+    Promise<Callable<? extends Deployable>> promise = Promise.promise();
+    factory.createVerticle2("guice:com.example.MissingClass", getClass().getClassLoader(), promise);
 
     promise
         .future()


### PR DESCRIPTION
Upgraded `GuiceVerticleFactory` to use the new Vert.x 5 `createVerticle2` API, which supports `Deployable`. This allows removing the deprecation warning suppression. Also updated the corresponding unit tests to verify the new API usage.

---
*PR created automatically by Jules for task [5169137830350759831](https://jules.google.com/task/5169137830350759831) started by @dclements*