### PR TITLE
Refactor VertxModule binding to use toProvider

### DIFF
--- a/init/src/main/java/com/larpconnect/njall/init/VertxModule.java
+++ b/init/src/main/java/com/larpconnect/njall/init/VertxModule.java
@@ -1,9 +1,8 @@
 package com.larpconnect.njall.init;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
 import io.vertx.core.Vertx;
+import jakarta.inject.Singleton;
 
 final class VertxModule extends AbstractModule {
   private final VertxProvider vertxProvider;
@@ -13,11 +12,7 @@ final class VertxModule extends AbstractModule {
   }
 
   @Override
-  protected void configure() {}
-
-  @Provides
-  @Singleton
-  Vertx provideVertx() {
-    return vertxProvider.get();
+  protected void configure() {
+    bind(Vertx.class).toProvider(vertxProvider).in(Singleton.class);
   }
 }


### PR DESCRIPTION
Refactored `VertxModule` to directly bind `Vertx` to the `VertxProvider` instance using `.toProvider()`, rather than using a `@Provides` method. This simplifies the binding and aligns with the user's request to avoid double wrapping. Also updated the `Singleton` annotation to use `jakarta.inject.Singleton`.

---
*PR created automatically by Jules for task [9869347146059341843](https://jules.google.com/task/9869347146059341843) started by @dclements*