### PR TITLE
Refactor: Centralize google-java-format version in Version Catalog

### DIFF
--- a/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
@@ -29,7 +29,7 @@ spotbugs {
 spotless {
     java {
         target("src/*/java/**/*.java")
-        googleJavaFormat("1.34.1") // Update to a version compatible with JDK 25
+        googleJavaFormat(libs.versions.google.java.format.get()) // Update to a version compatible with JDK 25
     }
     kotlinGradle {
         target("*.gradle.kts")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ checkstyle = "10.21.1"
 spotbugs = "4.9.8" # Tool version
 spotbugsPlugin = "6.4.8" # Plugin version
 spotless = "8.2.1"
+google-java-format = "1.34.1"
 protobuf = "4.33.5"
 protobufPlugin = "0.9.6"
 junit = "6.0.3"
@@ -24,6 +25,7 @@ jacoco = "0.8.14"
 beanutils = "1.11.0"
 log4j = "2.53.2"
 commons-lang3 = "3.20.0"
+archunit = "1.4.1"
 
 [libraries]
 # Core
@@ -59,7 +61,7 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 cucumber-java = { module = "io.cucumber:cucumber-java", version.ref = "cucumber" }
 cucumber-junit-platform-engine = { module = "io.cucumber:cucumber-junit-platform-engine", version.ref = "cucumber" }
-archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version = "1.4.1" }
+archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
Moved `google-java-format` version to `libs.versions.toml` to centralize version management.

---
*PR created automatically by Jules for task [18131215590788885353](https://jules.google.com/task/18131215590788885353) started by @dclements*