### PR TITLE
Refactor build logic to centralize core compiler options

### DIFF
--- a/.agents/pentiousinator/log.md
+++ b/.agents/pentiousinator/log.md
@@ -1,0 +1,11 @@
+## 2026-03-01 - JUnit 6 and Java 25
+
+**Learning:** This project uses JUnit 6 (version `6.0.3`), which requires Java 17+ and is fully compatible with Java 25. This was unexpected as JUnit 5 is still the dominant version in many environments. The build system also enforces Java 25 via toolchains and `--release` flags.
+
+**Action:** When working on tests or build configuration, ensure compatibility with JUnit 6 API and Java 25 language features. Do not downgrade to JUnit 5 or lower Java versions.
+
+## 2026-03-01 - Build Logic Organization
+
+**Learning:** The project uses a set of custom convention plugins in `buildSrc` (`larpconnect.java-common`, `larpconnect.quality`, etc.) to enforce standards. However, `larpconnect.quality` contained core compiler options (`encoding`, `-parameters`) mixed with linting options (`-Werror`, `-Xlint`), which violates separation of concerns.
+
+**Action:** Consolidate core compiler options (encoding, parameters) into the base Java plugin (`larpconnect.java-common`) and keep `larpconnect.quality` focused on linting and analysis tools.

--- a/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
@@ -15,6 +15,8 @@ java {
 
 tasks.withType<JavaCompile>().configureEach {
     options.release.set(25)
+    options.encoding = "UTF-8"
+    options.compilerArgs.add("-parameters")
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
@@ -89,6 +89,5 @@ dependencies {
 
 tasks.withType<JavaCompile>().configureEach {
     options.errorprone.disableWarningsInGeneratedCode.set(true)
-    options.encoding = "UTF-8"
-    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-processing", "-parameters"))
+    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-processing"))
 }

--- a/integration/src/test/java/com/larpconnect/njall/integration/BuildConfigurationTest.java
+++ b/integration/src/test/java/com/larpconnect/njall/integration/BuildConfigurationTest.java
@@ -1,0 +1,29 @@
+package com.larpconnect.njall.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import org.junit.jupiter.api.Test;
+
+/** Tests to verify that the build configuration is correct. */
+class BuildConfigurationTest {
+
+  @Test
+  void verifyCompilation_parametersFlagEnabled_preservesParameterNames() throws Exception {
+    Method method =
+        BuildConfigurationTest.class.getDeclaredMethod("exampleMethod", String.class, int.class);
+    Parameter[] parameters = method.getParameters();
+
+    assertThat(parameters[0].isNamePresent())
+        .as("Parameter names must be preserved by compilation with -parameters flag")
+        .isTrue();
+    assertThat(parameters[0].getName()).isEqualTo("param1");
+    assertThat(parameters[1].getName()).isEqualTo("param2");
+  }
+
+  @SuppressWarnings({"unused", "UnusedMethod", "UnusedVariable"})
+  private void exampleMethod(String param1, int param2) {
+    // No-op method for reflection testing
+  }
+}


### PR DESCRIPTION
Moved core Java compilation options (encoding, -parameters) from `larpconnect.quality` to `larpconnect.java-common` to improve separation of concerns and build robustness. Added a regression test to verify parameter name preservation.

---
*PR created automatically by Jules for task [3490020785418631480](https://jules.google.com/task/3490020785418631480) started by @dclements*