### PR TITLE
Make logback-classic runtimeOnly in application plugin

### DIFF
--- a/buildSrc/src/main/kotlin/larpconnect.application.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.application.gradle.kts
@@ -9,5 +9,5 @@ plugins {
 val libs = the<LibrariesForLibs>()
 
 dependencies {
-    implementation(libs.logback.classic)
+    runtimeOnly(libs.logback.classic)
 }


### PR DESCRIPTION
Made logback-classic a runtimeOnly dependency in the application convention plugin to prevent compile-time dependency on logging implementation details. Verified with build checks and classpath analysis.

---
*PR created automatically by Jules for task [7690452741499958501](https://jules.google.com/task/7690452741499958501) started by @dclements*