### PR TITLE
Add OpenAPI spec generation for protobufs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ beanutils = "1.11.0"
 log4j = "2.53.2"
 commons-lang3 = "3.20.0"
 archunit = "1.4.1"
+google-common-protos = "2.53.0"
 
 [libraries]
 # Core
@@ -48,6 +49,7 @@ errorprone-core = { module = "com.google.errorprone:error_prone_core", version.r
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone" }
 spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugs" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
+google-common-protos = { module = "com.google.api.grpc:proto-google-common-protos", version.ref = "google-common-protos" }
 
 # Testing
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.google.protobuf.gradle.GenerateProtoTask
+
 plugins {
     id("larpconnect.library")
     alias(libs.plugins.protobuf)
@@ -6,11 +8,34 @@ plugins {
 dependencies {
     implementation(project(":parent"))
     api(libs.protobuf.java)
+    implementation(libs.google.common.protos)
+}
+
+val goBinDir = layout.buildDirectory.dir("go-bin")
+val openApiPluginPath = goBinDir.map { it.file("protoc-gen-openapi").asFile.absolutePath }
+
+val installProtocGenOpenApi by tasks.registering(Exec::class) {
+    outputs.file(openApiPluginPath)
+    commandLine("go", "install", "github.com/google/gnostic/cmd/protoc-gen-openapi@latest")
+    environment("GOBIN", goBinDir.get().asFile.absolutePath)
 }
 
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
+    }
+    plugins {
+        create("openapi") {
+            path = openApiPluginPath.get()
+        }
+    }
+    generateProtoTasks {
+        all().forEach { task ->
+            task.dependsOn(installProtocGenOpenApi)
+            task.plugins {
+                create("openapi") { }
+            }
+        }
     }
 }
 

--- a/proto/src/main/proto/message.proto
+++ b/proto/src/main/proto/message.proto
@@ -2,13 +2,24 @@ syntax = "proto3";
 
 package com.larpconnect.njall.proto;
 
+import "google/api/annotations.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/empty.proto";
 
 option java_multiple_files = true;
 option java_package = "com.larpconnect.njall.proto";
+option go_package = "com.larpconnect.njall.proto";
 
 message Message {
   bytes trace_id = 1;
   string message_type = 2;
   google.protobuf.Any message = 3;
+}
+
+service MessageService {
+  rpc GetMessage(google.protobuf.Empty) returns (Message) {
+    option (google.api.http) = {
+      get: "/v1/message"
+    };
+  }
 }


### PR DESCRIPTION
Configures the :proto module to generate OpenAPI v3 specifications using protoc-gen-openapi (gnostic).
Adds a Gradle task to install the generator via Go.
Adds google-common-protos dependency to support HTTP annotations.
Updates message.proto with a dummy service and HTTP annotations to enable schema generation.

---
*PR created automatically by Jules for task [6540127895110007257](https://jules.google.com/task/6540127895110007257) started by @dclements*