### PR TITLE
Make compileJava depend on spotlessCheck

### DIFF
--- a/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
@@ -91,3 +91,7 @@ tasks.withType<JavaCompile>().configureEach {
     options.errorprone.disableWarningsInGeneratedCode.set(true)
     options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-processing"))
 }
+
+tasks.named("compileJava") {
+    dependsOn("spotlessCheck")
+}


### PR DESCRIPTION
Configure `compileJava` task to depend on `spotlessCheck` in the `larpconnect.quality` convention plugin.
This ensures that Spotless formatting checks are executed before Java compilation for all modules applying this plugin.
Verified by running `./gradlew compileJava` and observing `spotlessCheck` execution.
Ran `./gradlew check` to ensure no regressions.

---
*PR created automatically by Jules for task [13982127847125636487](https://jules.google.com/task/13982127847125636487) started by @dclements*