### PR TITLE
Add logback configurations for server and test

### DIFF
--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>server.log</file>
+        <encoder>
+            <pattern>%-5level %d{yyyy-MM-dd HH:mm:ss.SSS} [%marker] %logger{36} - %msg%n%ex</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+    </root>
+
+</configuration>

--- a/test/src/main/resources/logback-test.xml
+++ b/test/src/main/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level %d{yyyy-MM-dd HH:mm:ss.SSS} [%marker] %logger{36} - %msg%n%ex</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
Added logback configurations for server and test environments.

- `server/src/main/resources/logback.xml`: Configures logging to `server.log` with INFO level.
- `test/src/main/resources/logback-test.xml`: Configures logging to stdout with DEBUG level for tests.
- Used the requested log pattern: `%-5level %d{yyyy-MM-dd HH:mm:ss.SSS} [%marker] %logger{36} - %msg%n%ex`.

---
*PR created automatically by Jules for task [15801925348721264430](https://jules.google.com/task/15801925348721264430) started by @dclements*