### PR TITLE
🚧 Pentiousinator: Separate compiler args from quality plugin

### DIFF
--- a/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
@@ -16,7 +16,7 @@ java {
 tasks.withType<JavaCompile>().configureEach {
     options.release.set(25)
     options.encoding = "UTF-8"
-    options.compilerArgs.add("-parameters")
+    options.compilerArgs.addAll(listOf("-parameters", "-Werror", "-Xlint:all", "-Xlint:-processing"))
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts
@@ -89,7 +89,6 @@ dependencies {
 
 tasks.withType<JavaCompile>().configureEach {
     options.errorprone.disableWarningsInGeneratedCode.set(true)
-    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-processing"))
 }
 
 tasks.named("compileJava") {


### PR DESCRIPTION
Refactored build logic to move compiler arguments from `larpconnect.quality` plugin to `larpconnect.java-common` plugin.

💡 **What was changed**
- Removed `-Werror`, `-Xlint:all`, and `-Xlint:-processing` from `buildSrc/src/main/kotlin/larpconnect.quality.gradle.kts`.
- Added these arguments to `buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts`.

🎯 **Why it helps make the build system better**
- **Separation of Concerns:** Core compiler settings (like treating warnings as errors and enabling linting) are now centralized in the base Java configuration (`java-common`), while the `quality` plugin remains focused on external static analysis tools (Checkstyle, SpotBugs, ErrorProne).
- **Clarity:** It makes it easier to find and manage compiler flags without digging into the quality plugin configuration.
- **Robustness:** Ensures that any module applying `java-common` gets the standard strict compiler settings.

---
*PR created automatically by Jules for task [12298814862210984558](https://jules.google.com/task/12298814862210984558) started by @dclements*