### PR TITLE
Configure Shadow plugin for fatjar deployment

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:${libs.versions.spotbugsPlugin.get()}")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:${libs.versions.spotless.get()}")
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:${libs.versions.errorprone.plugin.get()}")
+    implementation(libs.shadow.gradle.plugin)
 
     // Workaround to expose version catalog accessors to precompiled script plugins
     compileOnly(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/buildSrc/src/main/kotlin/larpconnect.application.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.application.gradle.kts
@@ -1,13 +1,21 @@
 import org.gradle.accessors.dm.LibrariesForLibs
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     `application`
     id("larpconnect.java-common")
     id("larpconnect.testing")
+    id("com.gradleup.shadow")
 }
 
 val libs = the<LibrariesForLibs>()
 
 dependencies {
     runtimeOnly(libs.logback.classic)
+}
+
+tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier.set("")
+    archiveBaseName.set("larpconnect")
+    mergeServiceFiles()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ log4j = "2.53.2"
 commons-lang3 = "3.20.0"
 archunit = "1.4.1"
 google-common-protos = "2.66.0"
+shadow = "9.3.1"
 
 [libraries]
 # Core
@@ -70,9 +71,11 @@ mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.
 cucumber-java = { module = "io.cucumber:cucumber-java", version.ref = "cucumber" }
 cucumber-junit-platform-engine = { module = "io.cucumber:cucumber-junit-platform-engine", version.ref = "cucumber" }
 archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }
+shadow-gradle-plugin = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "shadow" }
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugsPlugin" }
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone-plugin" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }


### PR DESCRIPTION
Configure Shadow plugin for fatjar deployment

- Update `gradle/libs.versions.toml` to include Shadow plugin version 9.3.1.
- Add Shadow plugin dependency to `buildSrc/build.gradle.kts`.
- Configure `shadowJar` task in `larpconnect.application.gradle.kts` to:
    - Set `archiveClassifier` to empty string.
    - Set `archiveBaseName` to "larpconnect".
    - Enable `mergeServiceFiles()` for proper Vert.x SPI handling.
- This produces a `larpconnect.jar` in `server/build/libs`.

---
*PR created automatically by Jules for task [14304046268818471749](https://jules.google.com/task/14304046268818471749) started by @dclements*