### PR TITLE
build: make installProtocGenOpenApi conditional

### DIFF
--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -20,20 +20,25 @@ val installProtocGenOpenApi by tasks.registering(Exec::class) {
     environment("GOBIN", goBinDir.get().asFile.absolutePath)
 }
 
+val isUpdateOpenApi = gradle.startParameter.taskNames.contains("updateOpenApi")
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
     }
-    plugins {
-        create("openapi") {
-            path = openApiPluginPath.get()
+    if (isUpdateOpenApi) {
+        plugins {
+            create("openapi") {
+                path = openApiPluginPath.get()
+            }
         }
     }
     generateProtoTasks {
         all().forEach { task ->
-            task.dependsOn(installProtocGenOpenApi)
-            task.plugins {
-                create("openapi") { }
+            if (isUpdateOpenApi) {
+                task.dependsOn(installProtocGenOpenApi)
+                task.plugins {
+                    create("openapi") { }
+                }
             }
         }
     }


### PR DESCRIPTION
The `installProtocGenOpenApi` task and the `openapi` protoc plugin configuration are now conditionally applied only when `updateOpenApi` is present in the requested tasks. This prevents unnecessary dependency checks/downloads during standard builds.

---
*PR created automatically by Jules for task [8243490675100698228](https://jules.google.com/task/8243490675100698228) started by @dclements*