### PR TITLE
Fix installProtocGenOpenApi execution in shadowJar task

### DIFF
--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -14,13 +14,15 @@ dependencies {
 val goBinDir = layout.buildDirectory.dir("go-bin")
 val openApiPluginPath = goBinDir.map { it.file("protoc-gen-openapi").asFile.absolutePath }
 
+val isUpdateOpenApi = gradle.startParameter.taskNames.any { it.contains("updateOpenApi") }
+
 val installProtocGenOpenApi by tasks.registering(Exec::class) {
     outputs.file(openApiPluginPath)
     commandLine("go", "install", "github.com/google/gnostic/cmd/protoc-gen-openapi@latest")
     environment("GOBIN", goBinDir.get().asFile.absolutePath)
+    onlyIf { isUpdateOpenApi }
 }
 
-val isUpdateOpenApi = gradle.startParameter.taskNames.contains("updateOpenApi")
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"


### PR DESCRIPTION
Updated the isUpdateOpenApi flag check in proto/build.gradle.kts to properly capture when the updateOpenApi task is explicitly called by leveraging a substring `.any { it.contains("updateOpenApi") }` instead of exact object matching, ensuring fully qualified task names are supported. Also added an `onlyIf { isUpdateOpenApi }` condition to the `installProtocGenOpenApi` task to prevent it from implicitly running during standard builds like `shadowJar`.

---
*PR created automatically by Jules for task [11480675905781715310](https://jules.google.com/task/11480675905781715310) started by @dclements*