### PR TITLE
🚧 Pentiousinator: Add missing :init module to :bom

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
         api(project(":api"))
         api(project(":common"))
         api(project(":integration"))
+        api(project(":init"))
         api(project(":parent"))
         api(project(":proto"))
         api(project(":server"))


### PR DESCRIPTION
💡 What was changed:
Added `api(project(":init"))` to `bom/build.gradle.kts` constraints block.

🎯 Why it helps make the build system better:
Ensures that all modules appropriately implement `:parent` and `:test` and that `:bom` includes them. The `:init` module was missing from the `:bom` which could cause dependency issues for consumers of the BOM.

---
*PR created automatically by Jules for task [6001087791492504342](https://jules.google.com/task/6001087791492504342) started by @dclements*