### PR TITLE
📄 Nihiluxinator: Document Configuration Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ To run the server directly via Gradle:
 ./gradlew :server:run
 ```
 
+### Configuration
+
+LarpConnect's configuration can be modified through `config.json`. For detailed information on
+configuration settings, namespacing, and specifying custom configuration files, please refer to the
+[Configuration Guide](docs/configuration.md).
+
 ### Creating a Fatjar
 
 To create a standalone executable jar (fatjar):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,20 @@ then extracts the settings from the `larpconnect` namespace. If a setting is not
 namespace, the application will attempt to fall back to the root level of the configuration file,
 though placing settings in the namespace is strongly recommended.
 
+### Specifying the Configuration File
+
+By default, LarpConnect attempts to load the configuration from a file named `config.json` on the
+classpath. You can override this default behavior and specify a custom configuration file location
+by setting the `njall.config.resource` system property when starting the application.
+
+For example, to load a configuration file named `custom-config.json`:
+
+```bash
+java -Dnjall.config.resource=custom-config.json -jar server/build/libs/larpconnect.jar
+```
+
+The specified resource must be available on the classpath.
+
 ## Supported Properties
 
 Currently, LarpConnect supports the following configuration properties:


### PR DESCRIPTION
💡 **What was changed**: 
- Added a section to `README.md` referencing `docs/configuration.md` to make configuration instructions easily accessible.
- Updated `docs/configuration.md` to explicitly state how to use the `-Dnjall.config.resource` JVM property to provide a custom configuration file, bringing the documentation in line with how `VerticleLifecycle.java` resolves configuration files.

Consistency edits that were needed:
- Modified the README to ensure it has a dedicated Configuration section right after the Run Locally section, similar to how it points to other critical guides.
- Documented the existing fallback behavior in `docs/configuration.md` explicitly as it relates to JVM properties.

🎯 **Why the documentation is helpful**:
- Understanding how to manage application configuration is essential for developers, particularly when running multiple instances or configuring for tests/different environments. The `-Dnjall.config.resource` system property was implemented in code but lacked documentation, which this PR resolves.

---
*PR created automatically by Jules for task [4522028797002183525](https://jules.google.com/task/4522028797002183525) started by @dclements*