### PR TITLE
Enable spotless on markdown files

### DIFF
--- a/.agents/SKILLS.md
+++ b/.agents/SKILLS.md
@@ -1,41 +1,44 @@
 # Modular Skill Registry
 
-This document defines the specialized capabilities available to AI agents such as Jules. Agents must reference the corresponding file in `.agents/skills/` when a task falls within the defined "Activation Trigger."
+This document defines the specialized capabilities available to AI agents such
+as Jules. Agents must reference the corresponding file in `.agents/skills/` when
+a task falls within the defined "Activation Trigger."
 
 ## 1. Core Engineering Skills (Always Active)
 
-| Skill Name | Activation Trigger | Source File |
-| :--- | :--- | :--- |
-| **Java 25 Mastery** | Any `.java` file modification | `.agents/skills/java.md` |
-| **Common Gradle Skills** | All projects that require compiling the code   | `.agents/skills/common.md`  |
-| **Testing Standards** | Any `src/test` modification or work in `:integration` | `.agents/skills/testing.md` |
-| **Git Usage**         | Downloading or pushing a commit.            | `.agents/skills/git.md`     |
-| **Context Documentation** | Writing a javadoc, encountering an annotation | `.agents/skills/context.md` |
+| Skill Name                | Activation Trigger                                    | Source File                 |
+| :------------------------ | :---------------------------------------------------- | :-------------------------- |
+| **Java 25 Mastery**       | Any `.java` file modification                         | `.agents/skills/java.md`    |
+| **Common Gradle Skills**  | All projects that require compiling the code          | `.agents/skills/common.md`  |
+| **Testing Standards**     | Any `src/test` modification or work in `:integration` | `.agents/skills/testing.md` |
+| **Git Usage**             | Downloading or pushing a commit.                      | `.agents/skills/git.md`     |
+| **Context Documentation** | Writing a javadoc, encountering an annotation         | `.agents/skills/context.md` |
 
 ## 2. Third Party Skills (Situational)
 
 If working with Render, load Render's documentation from context7.
 
-| Skill Name | Activation Trigger | Source File |
-| :--- | :--- | :--- |
-| Render Debug | Debugging Render Output | [Render Debug](https://github.com/render-oss/skills/blob/main/skills/render-debug/SKILL.md) |
-| Render Deploy | Publish Code for further testing | [Render Deploy](https://github.com/render-oss/skills/blob/main/skills/render-deploy/SKILL.md)
+| Skill Name    | Activation Trigger               | Source File                                                                                   |
+| :------------ | :------------------------------- | :-------------------------------------------------------------------------------------------- |
+| Render Debug  | Debugging Render Output          | [Render Debug](https://github.com/render-oss/skills/blob/main/skills/render-debug/SKILL.md)   |
+| Render Deploy | Publish Code for further testing | [Render Deploy](https://github.com/render-oss/skills/blob/main/skills/render-deploy/SKILL.md) |
 
 ## 3. Domain-Specific Skills (Contextual)
 
-| Skill Name | Activation Trigger | Source File |
-| :--- | :--- | :--- |
-| **Guice Dependency** | Modifications to `*Module.java` | `.agents/skills/guice_di.md` |
-| **Gradle Mastery**   | Modification of any kotlin (`*.kts`, `*.kt`), build, or setting file | `.agents/skills/build.md` |
-| **Vert.x Mastery**   | Modification of a `*Verticle.java` file, interacting with a `vertx` object, modification of `:server` | `.agents/skills/vertx.md` |
-| **Data Handling**      | Any modifications to JSON or CSV files or work inside of `:proto` | `.jules/skills/data.md` |
-| **Markdown Documentation**  | Building documentation in markdown (`.md`)   | `.jules/skills/markdown.md` |
-| **Breakglass Documentation** | If you are "stuck" on a problem             | `.jules/skills/breakglass.md` |
-
+| Skill Name                   | Activation Trigger                                                                                    | Source File                   |
+| :--------------------------- | :---------------------------------------------------------------------------------------------------- | :---------------------------- |
+| **Guice Dependency**         | Modifications to `*Module.java`                                                                       | `.agents/skills/guice_di.md`  |
+| **Gradle Mastery**           | Modification of any kotlin (`*.kts`, `*.kt`), build, or setting file                                  | `.agents/skills/build.md`     |
+| **Vert.x Mastery**           | Modification of a `*Verticle.java` file, interacting with a `vertx` object, modification of `:server` | `.agents/skills/vertx.md`     |
+| **Data Handling**            | Any modifications to JSON or CSV files or work inside of `:proto`                                     | `.jules/skills/data.md`       |
+| **Markdown Documentation**   | Building documentation in markdown (`.md`)                                                            | `.jules/skills/markdown.md`   |
+| **Breakglass Documentation** | If you are "stuck" on a problem                                                                       | `.jules/skills/breakglass.md` |
 
 ## 3. Delegation Protocol
 
-If a task involves multiple domains, load all relevant skills in the following order:
+If a task involves multiple domains, load all relevant skills in the following
+order:
+
 1. Core Engineering
 2. Third Party
 3. Domain-Specific

--- a/.agents/logs/nifftyinator/log.md
+++ b/.agents/logs/nifftyinator/log.md
@@ -1,5 +1,11 @@
 ## 2025-02-27 - [Variable and Error Catch Grouping]
 
-**Learning:** It's quite common for java files in this project to define a variable before assigning it, especially with things like Java Optional, Guice and Vert.x. It's also common to have multiple error catch clauses of the same action.
+**Learning:** It's quite common for java files in this project to define a
+variable before assigning it, especially with things like Java Optional, Guice
+and Vert.x. It's also common to have multiple error catch clauses of the same
+action.
 
-**Action:** Whenever I encounter variables that are instantly assigned, I should use `var`. Also when I encounter consecutive try-catch clauses that perform the same logging/error operation, I should group them using `|`. E.g. `catch (ExecutionException | TimeoutException e)`.
+**Action:** Whenever I encounter variables that are instantly assigned, I should
+use `var`. Also when I encounter consecutive try-catch clauses that perform the
+same logging/error operation, I should group them using `|`. E.g.
+`catch (ExecutionException | TimeoutException e)`.

--- a/.agents/pentiousinator/log.md
+++ b/.agents/pentiousinator/log.md
@@ -1,11 +1,22 @@
 ## 2026-03-01 - JUnit 6 and Java 25
 
-**Learning:** This project uses JUnit 6 (version `6.0.3`), which requires Java 17+ and is fully compatible with Java 25. This was unexpected as JUnit 5 is still the dominant version in many environments. The build system also enforces Java 25 via toolchains and `--release` flags.
+**Learning:** This project uses JUnit 6 (version `6.0.3`), which requires Java
+17+ and is fully compatible with Java 25. This was unexpected as JUnit 5 is
+still the dominant version in many environments. The build system also enforces
+Java 25 via toolchains and `--release` flags.
 
-**Action:** When working on tests or build configuration, ensure compatibility with JUnit 6 API and Java 25 language features. Do not downgrade to JUnit 5 or lower Java versions.
+**Action:** When working on tests or build configuration, ensure compatibility
+with JUnit 6 API and Java 25 language features. Do not downgrade to JUnit 5 or
+lower Java versions.
 
 ## 2026-03-01 - Build Logic Organization
 
-**Learning:** The project uses a set of custom convention plugins in `buildSrc` (`larpconnect.java-common`, `larpconnect.quality`, etc.) to enforce standards. However, `larpconnect.quality` contained core compiler options (`encoding`, `-parameters`) mixed with linting options (`-Werror`, `-Xlint`), which violates separation of concerns.
+**Learning:** The project uses a set of custom convention plugins in `buildSrc`
+(`larpconnect.java-common`, `larpconnect.quality`, etc.) to enforce standards.
+However, `larpconnect.quality` contained core compiler options (`encoding`,
+`-parameters`) mixed with linting options (`-Werror`, `-Xlint`), which violates
+separation of concerns.
 
-**Action:** Consolidate core compiler options (encoding, parameters) into the base Java plugin (`larpconnect.java-common`) and keep `larpconnect.quality` focused on linting and analysis tools.
+**Action:** Consolidate core compiler options (encoding, parameters) into the
+base Java plugin (`larpconnect.java-common`) and keep `larpconnect.quality`
+focused on linting and analysis tools.

--- a/.agents/skills/breakglass.md
+++ b/.agents/skills/breakglass.md
@@ -1,24 +1,29 @@
 # Skill: Handling being Stuck
 
 ## Domain Context
+
 This skill handles specific problem cases that you may be encountering.
 
 ## Technical Constraints
 
-There are several technical constraints in this project that we have found AI agents consistently have trouble with. This is a guide to help you navigate those. 
+There are several technical constraints in this project that we have found AI
+agents consistently have trouble with. This is a guide to help you navigate
+those.
 
 To start:
 
 If your problem is related to:
 
-* **Instantiation**: Read `.agents/skills/guice_di.md`
-* **Test Coverage**: Read `.agents/skills/testing.md`
-* **Context Annotations**: Read `.agents/skills/context.md`
-* **Data Files**: Read `.agents/skills/data.md`
+- **Instantiation**: Read `.agents/skills/guice_di.md`
+- **Test Coverage**: Read `.agents/skills/testing.md`
+- **Context Annotations**: Read `.agents/skills/context.md`
+- **Data Files**: Read `.agents/skills/data.md`
 
-Read these regardless of if you have met the trigger conditions specified in `.jules/SKILLS.md`
+Read these regardless of if you have met the trigger conditions specified in
+`.jules/SKILLS.md`
 
-If none of the above apply or if your problem is still not solved, move to **Specific Guidance** here.
+If none of the above apply or if your problem is still not solved, move to
+**Specific Guidance** here.
 
 ## Specific Guidance
 
@@ -26,7 +31,10 @@ If none of the above apply or if your problem is still not solved, move to **Spe
 
 Strategies:
 
-* **Breaking up logic**: Breaking blocks of code, especially blocks of code with internal control logic, out into new methods, so instead of complex code blocks you end up with:
+- **Breaking up logic**: Breaking blocks of code, especially blocks of code with
+  internal control logic, out into new methods, so instead of complex code
+  blocks you end up with:
+
   ```
     public void method() {
       if (fooCondition) {
@@ -39,9 +47,19 @@ Strategies:
     }
   ```
 
-  Each of `fooLogic()`, `barLogic()`, and `bazLogic()` may have their own control structures (loops etc), but this reduces their complexity noticeably. If needed for testing purposes you can also put these behind an interface and then mock that interface.
-* **Removing Defensive Branches**: It is not unusual to add "defensive branches" that are impossible to reach. Confirm that they are impossible to reach via `./gradlew check` and by mentally reasoning through the function, but if they are impossible to reach you may just be able to remove them as dead code.
-* **Law of Demeter**: Also called the "one dot rule." If a method is calling functions on things that it got from functions of other things, that's a strong signal that you need multiple methods. Even something as simple as:
+  Each of `fooLogic()`, `barLogic()`, and `bazLogic()` may have their own
+  control structures (loops etc), but this reduces their complexity noticeably.
+  If needed for testing purposes you can also put these behind an interface and
+  then mock that interface.
+
+- **Removing Defensive Branches**: It is not unusual to add "defensive branches"
+  that are impossible to reach. Confirm that they are impossible to reach via
+  `./gradlew check` and by mentally reasoning through the function, but if they
+  are impossible to reach you may just be able to remove them as dead code.
+- **Law of Demeter**: Also called the "one dot rule." If a method is calling
+  functions on things that it got from functions of other things, that's a
+  strong signal that you need multiple methods. Even something as simple as:
+
   ```
     public void method() {
       var tmp = foo.fetchValue();
@@ -54,4 +72,5 @@ Strategies:
     }
   ```
 
-  Note that this doesn't usually apply when working with **record** objects, but it does apply when working when objects that involve actual application logic.
+  Note that this doesn't usually apply when working with **record** objects, but
+  it does apply when working when objects that involve actual application logic.

--- a/.agents/skills/common.md
+++ b/.agents/skills/common.md
@@ -2,22 +2,28 @@
 
 ## Purpose
 
-This skill provides guidance on how to develop in this environment with these build tools.
+This skill provides guidance on how to develop in this environment with these
+build tools.
 
 ## Technical Constraints
 
-* The system uses gradle 9+ with the graddle wrapper (`./gradlew`) as the main entry point.
-* The system is a multimodule project. a `<command>` can be run with either `./gradlew <command>` (to run it across all modules) or `./gradlew :<module>:<command>` (for a specific module)
+- The system uses gradle 9+ with the graddle wrapper (`./gradlew`) as the main
+  entry point.
+- The system is a multimodule project. a `<command>` can be run with either
+  `./gradlew <command>` (to run it across all modules) or
+  `./gradlew :<module>:<command>` (for a specific module)
 
 ## Specific Guidance
 
-* Run gradle with `--stacktrace` when debugging.
-* Always run `./gradlew spotlessApply check build` before submitting code.
+- Run gradle with `--stacktrace` when debugging.
+- Always run `./gradlew spotlessApply check build` before submitting code.
 
 ### Common Commands
 
- * `./gradlew check`: Executes the full suite of tests, static analysis, and formatting checks. No PR shall be merged if `./gradlew check` fails.
- * `./gradlew spotlessApply`: Automatically corrects source code formatting according to the defined standard. Always run this before submitting.
- * `./gradlew :batch:run --args="..."`: Executes the application in batch mode.
- * `./gradlew :repl:run`: Initializes the interactive REPL session.
- * `./gradlew build`: Builds the entire project
+- `./gradlew check`: Executes the full suite of tests, static analysis, and
+  formatting checks. No PR shall be merged if `./gradlew check` fails.
+- `./gradlew spotlessApply`: Automatically corrects source code formatting
+  according to the defined standard. Always run this before submitting.
+- `./gradlew :batch:run --args="..."`: Executes the application in batch mode.
+- `./gradlew :repl:run`: Initializes the interactive REPL session.
+- `./gradlew build`: Builds the entire project

--- a/.agents/skills/context.md
+++ b/.agents/skills/context.md
@@ -2,21 +2,24 @@
 
 ## Domain Context
 
-This skill handles the format for context engineering prompts, both for reading and writing. 
+This skill handles the format for context engineering prompts, both for reading
+and writing.
 
 ## Functional Definition
 
 ### AiContext Annotation
 
-The system supports an `@AiContract` annotation. This annotation is a **Hard Invariant**. It defines the "Logical Physics" of a method. When generating or refactoring code, you must satisfy the contract's proof obligations.
+The system supports an `@AiContract` annotation. This annotation is a **Hard
+Invariant**. It defines the "Logical Physics" of a method. When generating or
+refactoring code, you must satisfy the contract's proof obligations.
 
-| Field | Format | Purpose | AI Obligation |
-|-------|--------|---------|---------------|
-| require | Array<LaTeX> | Preconditions | You must verify these are true before the call. Assume $⊥$ (null) is forbidden unless `@Nullable` is present |
-| ensure  | Array<LaTeX> | Postconditions | You must guarantee these are true upon exit. Use $res$ for return and $this′$ for post-state |
-| invariants | Array<LaTeX> | Conditions that must remain true throughout execution | Assume that these are always true through the duration of execution | 
-| tags | Array<Enum>  | Advisory statements on the nature of the method | Be accurate in documenting these and treat them as if true. In the absence of a tag a method may be assumed to be its inverse (so if there is no `IDEMPOTENT` tag it may be assumed to be **NOT** `IDEMPOTENT`) |
-| implementationHint | String | Intent communication | A high-level semantic anchor for the "Reasoning Path" of the method |
+| Field              | Format       | Purpose                                               | AI Obligation                                                                                                                                                                                                   |
+| ------------------ | ------------ | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| require            | Array<LaTeX> | Preconditions                                         | You must verify these are true before the call. Assume $⊥$ (null) is forbidden unless `@Nullable` is present                                                                                                    |
+| ensure             | Array<LaTeX> | Postconditions                                        | You must guarantee these are true upon exit. Use $res$ for return and $this′$ for post-state                                                                                                                    |
+| invariants         | Array<LaTeX> | Conditions that must remain true throughout execution | Assume that these are always true through the duration of execution                                                                                                                                             |
+| tags               | Array<Enum>  | Advisory statements on the nature of the method       | Be accurate in documenting these and treat them as if true. In the absence of a tag a method may be assumed to be its inverse (so if there is no `IDEMPOTENT` tag it may be assumed to be **NOT** `IDEMPOTENT`) |
+| implementationHint | String       | Intent communication                                  | A high-level semantic anchor for the "Reasoning Path" of the method                                                                                                                                             |
 
 Example:
 
@@ -35,53 +38,74 @@ ImmutableSet<Node> fetchReachableNodes(Graph g);
 
 #### LaTeX style guide and language rules
 
-Text may be written either directly in LaTeX (e.g., `\bot`) or using the text character equivalents (e.g., `⊥`). All text should be escaped into math mode (i.e., `$x$` should be read as "math mode for `x`").
+Text may be written either directly in LaTeX (e.g., `\bot`) or using the text
+character equivalents (e.g., `⊥`). All text should be escaped into math mode
+(i.e., `$x$` should be read as "math mode for `x`").
 
 1. **Result Reference**: Always refer to the return value as `$res$`
-2. **State Transition**: Refer to the object's state before the call as `$this$` and after the call as `$this'$`
+2. **State Transition**: Refer to the object's state before the call as `$this$`
+   and after the call as `$this'$`
 3. **Nullity**: Use `\neq ⊥` to indicate non-null and `=⊥` for null
-4. **Sets/Collections**: Use standard set notation (`∈`,`⊂`,`∪`,`∩`) for collection operations
-5. **Symbols** (this is an incomplete list, and you may use other symbols out of type theory / computer science freely):
-    - `⊥` Null/Bottom state
-    - `⊤` Top state
-    - `∅` Empty set, empty string, blank (but not `null`)
-    - `¬` Negation
-    - `⟹` Logical implication
-    - `≡` Logical equivalence or invariantly-equal-to, equal for all circumstances to
-    - `≜` Defined as. So `$a ≜ b$` means that `$a$` is being defined as being equal to `$b$`
-    - `=` Is equal to. Equivalent to `==` in java.
-    - `≠` Not equal to. Equivalent to `!=` in java.
-    - `⟶` Happens before. So `a ⟶ b` means "``$a$` happens before `$b$`" in concurrent contexts.
-    - `↦` "becomes" or "maps to" so `$float ↦ int$` says that the float is converted into an int
-    - `:-` "assuming" or "given", so `$Γ :- x$` says "given the assumptions in `$Γ$` and the invariants we have stated then `$x$`". If nothing is placed before the `:-` then it is "given the invariants we have stated then `$x$`"
-    - `∀` forall, for example `$∀ s ∈ Skills : s.id ≠ ⊥$` would say "for all of `$s$` in `$Skills$` `s.id` is not `null`"
-    - `∃` there exists, for example `$∃ p ∈ Paths : Accessible(p)$` would say "there exists a `$p$` in `$Paths$` where `Accessible(p)` is `true`"
-    - `ℤ` set of integers
-    - `ℕ⁺` set of strictly positive natural numbers (not including zero)
+4. **Sets/Collections**: Use standard set notation (`∈`,`⊂`,`∪`,`∩`) for
+   collection operations
+5. **Symbols** (this is an incomplete list, and you may use other symbols out of
+   type theory / computer science freely):
+   - `⊥` Null/Bottom state
+   - `⊤` Top state
+   - `∅` Empty set, empty string, blank (but not `null`)
+   - `¬` Negation
+   - `⟹` Logical implication
+   - `≡` Logical equivalence or invariantly-equal-to, equal for all
+     circumstances to
+   - `≜` Defined as. So `$a ≜ b$` means that `$a$` is being defined as being
+     equal to `$b$`
+   - `=` Is equal to. Equivalent to `==` in java.
+   - `≠` Not equal to. Equivalent to `!=` in java.
+   - `⟶` Happens before. So `a ⟶ b` means "``$a$` happens before `$b$`" in
+     concurrent contexts.
+   - `↦` "becomes" or "maps to" so `$float ↦ int$` says that the float is
+     converted into an int
+   - `:-` "assuming" or "given", so `$Γ :- x$` says "given the assumptions in
+     `$Γ$` and the invariants we have stated then `$x$`". If nothing is placed
+     before the `:-` then it is "given the invariants we have stated then `$x$`"
+   - `∀` forall, for example `$∀ s ∈ Skills : s.id ≠ ⊥$` would say "for all of
+     `$s$` in `$Skills$` `s.id` is not `null`"
+   - `∃` there exists, for example `$∃ p ∈ Paths : Accessible(p)$` would say
+     "there exists a `$p$` in `$Paths$` where `Accessible(p)` is `true`"
+   - `ℤ` set of integers
+   - `ℕ⁺` set of strictly positive natural numbers (not including zero)
 6. **Use**:
-    - `const(x)` to indicate that `$x$` does not change and will not be modified. Implies _const correctness_ or **deep immutability** (so `$const(this)$` says that it is expected that everyhing is immutable all the way down)
-    - `old(x)` The value of `$x$` at the start of the method
-    - `ID(x)` The unique identifier, if applicable, for `$x$`
-    - `inout(x)` Indicates that `$x$` is an InOut or return parameter: the response to the method will come in the form of modifying `$x$`
+   - `const(x)` to indicate that `$x$` does not change and will not be modified.
+     Implies _const correctness_ or **deep immutability** (so `$const(this)$`
+     says that it is expected that everyhing is immutable all the way down)
+   - `old(x)` The value of `$x$` at the start of the method
+   - `ID(x)` The unique identifier, if applicable, for `$x$`
+   - `inout(x)` Indicates that `$x$` is an InOut or return parameter: the
+     response to the method will come in the form of modifying `$x$`
 
-Remember that in LaTeX `$` is used to indicate math mode, which you _should_ use the same way.
+Remember that in LaTeX `$` is used to indicate math mode, which you _should_ use
+the same way.
 
 ### Additional Annotations
 
-Where there are is an option to use another annotation it **should always be preferred** to inclusion in the `@AiContext`.
+Where there are is an option to use another annotation it **should always be
+preferred** to inclusion in the `@AiContext`.
 
-Annotations from ErrorProne, JSR305, Checker framework, etc are **Hard Invariants**. All parameters and methods are assumed `@Nonnull` by default and all local variables are assumed `final` by default. A partial list of these annotations and how to interpret them is as follows:
+Annotations from ErrorProne, JSR305, Checker framework, etc are **Hard
+Invariants**. All parameters and methods are assumed `@Nonnull` by default and
+all local variables are assumed `final` by default. A partial list of these
+annotations and how to interpret them is as follows:
 
-| Annotation   |    Meaning   |  Scope       | Your Obligation | Enforcement |
-|--------------|--------------|--------------|-----------------|-------------|
-| `@ThreadSafe` | The annotated class is fully thread safe and responsible for managing its own internal thread safety. | Classes and Interfaces | Every method must be safe for concurrent execution. You are forbidden from using non-thread-safe primitives (like HashMap) or unsynchronized shared state | ErrorProne, Spotbugs |
-| `@Immutable` | The annotated class is fully _immutable_ and cannot be changed. | Classes or Interfaces | You must ensure all fields are final and any referenced types are also immutable. Do not suggest mutation methods (setters) | ErrorProne, Spotbugs |
-| `@CanIgnoreReturnValue` | This method is called for its side effects (e.g., logging) and its result can be discarded | Methods | Do not wrap it in an unused variable assignment | ErrorProne |
-| `@DoNotMock`            | Should not be mocked. | Classes, Interfaces | Do not mock it with mockito. Create fakes or real instantiations if needed |  ErrorProne |
-| `@MustBeClosed` | This method returns a resource (Stream, Connection, etc.) that must be closed | Methods | Wrap all return values in a `try-with-resource` block immediately | ErrorProne |
-| `@GuardedBy`   | This field is protected by a specific lock | Instance fields | You MUST acquire the specified lock (e.g., `@GuardedBy("mutex")`) before accessing this field. Every access must be wrapped in a synchronized block or lock-hold | ErrorProne |
-| `@Var`         | This variable may be overwritten | Local variables, instance variables | You are forbidden from reassigning any local variable or parameter **unless** it is explicitly marked with `@Var` | ErrorProne |
-| `@BuildWith(<Module>)` | Specifies the "Source of Truth" **public** Guice module for this class | Classes, Interfaces | When you want to instantiate this object outside of this package, you must build an `Injector` with this `<Module>` | JVM, ArchUnit |
-| `@InstallInstead(<Module>)` | Signals a delegated module installation. | Module classes | If you were going to `install()` the annotated module, install the target class (`<Module>`) instead to maintain architectural boundaries. Does not apply to `<Module>`'s installation. | JVM, ArchUnit |
-| `@Nullable`  | This value MAY be null  | Methods, return values, fields | Null needs to be explicitly considered and handled | Spotbugs, ErrorProne |
-| `@Untainted` | Denotes a reference that is untainted, i.e. can be trusted | Method parameters, fields, and return values  | This is a desireable state achieved by running a string through a sanitizer. `@Tainted` is the default for all strings coming form the outside. | 
+| Annotation                  | Meaning                                                                                               | Scope                                        | Your Obligation                                                                                                                                                                         | Enforcement          |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `@ThreadSafe`               | The annotated class is fully thread safe and responsible for managing its own internal thread safety. | Classes and Interfaces                       | Every method must be safe for concurrent execution. You are forbidden from using non-thread-safe primitives (like HashMap) or unsynchronized shared state                               | ErrorProne, Spotbugs |
+| `@Immutable`                | The annotated class is fully _immutable_ and cannot be changed.                                       | Classes or Interfaces                        | You must ensure all fields are final and any referenced types are also immutable. Do not suggest mutation methods (setters)                                                             | ErrorProne, Spotbugs |
+| `@CanIgnoreReturnValue`     | This method is called for its side effects (e.g., logging) and its result can be discarded            | Methods                                      | Do not wrap it in an unused variable assignment                                                                                                                                         | ErrorProne           |
+| `@DoNotMock`                | Should not be mocked.                                                                                 | Classes, Interfaces                          | Do not mock it with mockito. Create fakes or real instantiations if needed                                                                                                              | ErrorProne           |
+| `@MustBeClosed`             | This method returns a resource (Stream, Connection, etc.) that must be closed                         | Methods                                      | Wrap all return values in a `try-with-resource` block immediately                                                                                                                       | ErrorProne           |
+| `@GuardedBy`                | This field is protected by a specific lock                                                            | Instance fields                              | You MUST acquire the specified lock (e.g., `@GuardedBy("mutex")`) before accessing this field. Every access must be wrapped in a synchronized block or lock-hold                        | ErrorProne           |
+| `@Var`                      | This variable may be overwritten                                                                      | Local variables, instance variables          | You are forbidden from reassigning any local variable or parameter **unless** it is explicitly marked with `@Var`                                                                       | ErrorProne           |
+| `@BuildWith(<Module>)`      | Specifies the "Source of Truth" **public** Guice module for this class                                | Classes, Interfaces                          | When you want to instantiate this object outside of this package, you must build an `Injector` with this `<Module>`                                                                     | JVM, ArchUnit        |
+| `@InstallInstead(<Module>)` | Signals a delegated module installation.                                                              | Module classes                               | If you were going to `install()` the annotated module, install the target class (`<Module>`) instead to maintain architectural boundaries. Does not apply to `<Module>`'s installation. | JVM, ArchUnit        |
+| `@Nullable`                 | This value MAY be null                                                                                | Methods, return values, fields               | Null needs to be explicitly considered and handled                                                                                                                                      | Spotbugs, ErrorProne |
+| `@Untainted`                | Denotes a reference that is untainted, i.e. can be trusted                                            | Method parameters, fields, and return values | This is a desireable state achieved by running a string through a sanitizer. `@Tainted` is the default for all strings coming form the outside.                                         |

--- a/.agents/skills/data.md
+++ b/.agents/skills/data.md
@@ -1,17 +1,23 @@
 # Skill: Data and I/O
 
 ## Domain Context
-This skill handles the reading and writing of JSON, CSV, Protobuf, and other such formats.
+
+This skill handles the reading and writing of JSON, CSV, Protobuf, and other
+such formats.
 
 ## Technical Constraints
 
- * Data Interchange: Protobuf is the primary specification format. All data to be exchanged should have a representation in protobuf.
- * JSON: Protobuf should generally be turned into JSON before using it to respond to a web request unless explicitly requested otherwise.
- * Schemas: Schemas (in protobuf and/or OpenAPI) must be kept up to date to ensure proper documentation of data exchange formats.
- * Do not use unicode escapes in JSON files. They are UTF-8 files and the encoded character is always preferable.
+- Data Interchange: Protobuf is the primary specification format. All data to be
+  exchanged should have a representation in protobuf.
+- JSON: Protobuf should generally be turned into JSON before using it to respond
+  to a web request unless explicitly requested otherwise.
+- Schemas: Schemas (in protobuf and/or OpenAPI) must be kept up to date to
+  ensure proper documentation of data exchange formats.
+- Do not use unicode escapes in JSON files. They are UTF-8 files and the encoded
+  character is always preferable.
 
 ## Specific Guidance
 
-* Use Guava IO when possible for data reading and writing.
-* If the tool doesn't exist in guava, Apache Commons IO can be used.
-* If JSON must be parsed independently from Protobuf, use Gson.
+- Use Guava IO when possible for data reading and writing.
+- If the tool doesn't exist in guava, Apache Commons IO can be used.
+- If JSON must be parsed independently from Protobuf, use Gson.

--- a/.agents/skills/git.md
+++ b/.agents/skills/git.md
@@ -1,20 +1,29 @@
 # Skill: Git
 
 ## Domain Context
+
 This skill handles the proper use of git.
 
 ## Technical Constraints
 
-* At the start of the session, run `git config --global credential.helper 'cache --timeout=3600'` and ensure the provided token is cached.
-* There is a github action that monitors compliance with the various rules. Always fix (non-billing) issues that come from these actions.
-* Branch names should begin with the name of the agent and a slash, so `jules/` for jules, `ona/` for ona, etc. If the agent has been "renamed" (e.g., with "you are `<foo>`") then "`<foo>`" is the name of the agent.
+- At the start of the session, run
+  `git config --global credential.helper 'cache --timeout=3600'` and ensure the
+  provided token is cached.
+- There is a github action that monitors compliance with the various rules.
+  Always fix (non-billing) issues that come from these actions.
+- Branch names should begin with the name of the agent and a slash, so `jules/`
+  for jules, `ona/` for ona, etc. If the agent has been "renamed" (e.g., with
+  "you are `<foo>`") then "`<foo>`" is the name of the agent.
 
 ## Specific Guidance
 
-### Git Messages 
+### Git Messages
 
-1. The first line of every commit message must be 74 characters or less and must be in plain text.
-2. The body of the commit message is separated by at least 1 whitespace line from the first line and should be in markdown.
+1. The first line of every commit message must be 74 characters or less and must
+   be in plain text.
+2. The body of the commit message is separated by at least 1 whitespace line
+   from the first line and should be in markdown.
 3. Lines of the body of the commit message should not exceed 100 characters.
 4. Commit messages should be descriptive of what was done in the commit.
-5. Commit messages should be professional and written with an eye toward future developers.
+5. Commit messages should be professional and written with an eye toward future
+   developers.

--- a/.agents/skills/gradle.md
+++ b/.agents/skills/gradle.md
@@ -1,59 +1,82 @@
 # Skill: Gradle and Build Files
 
 ## Domain Context
-This skill handles working with gradle and all build associated files (e.g., settings.gradle)
+
+This skill handles working with gradle and all build associated files (e.g.,
+settings.gradle)
 
 ## Technical Constraints
 
-1. Use gradle 9+ with the kotlin DSL. Compile using Java 25+. The gradle wrapper (`./gradlew`) is the primary entry point. 
-2. Dependency Governance: Versioning must be maintained exclusively within the Version Catalog to facilitate streamlined updates and auditing
-3. Use the most recent version of dependencies unless there is a documented reason to avoid a particular dependency or set of dependencies.
+1. Use gradle 9+ with the kotlin DSL. Compile using Java 25+. The gradle wrapper
+   (`./gradlew`) is the primary entry point.
+2. Dependency Governance: Versioning must be maintained exclusively within the
+   Version Catalog to facilitate streamlined updates and auditing
+3. Use the most recent version of dependencies unless there is a documented
+   reason to avoid a particular dependency or set of dependencies.
 
 ## Specific Guidance
 
-* Gradle modules should be named for what they are but published as `larpconnect-<module name>`, e.g., `:core` should become `larpconnect-core`. An exception to this is the `:server` module, which should be published as `:larpconnect`
-* Store common build infrastructure in a `buildSrc`.
-* Maintain alphabetical ordering for dependencies.
-* Alphabetically order the type of dependency import as well, e.g., api, implementation, testRuntime, etc. Put a single whitespace line between these blocks.
-* Vulnerability Scanning: Execution of ./gradlew dependencyCheckAnalyze is mandatory upon the addition of any external library to mitigate supply chain risks.
-* Store common configurations in `buildSrc`
+- Gradle modules should be named for what they are but published as
+  `larpconnect-<module name>`, e.g., `:core` should become `larpconnect-core`.
+  An exception to this is the `:server` module, which should be published as
+  `:larpconnect`
+- Store common build infrastructure in a `buildSrc`.
+- Maintain alphabetical ordering for dependencies.
+- Alphabetically order the type of dependency import as well, e.g., api,
+  implementation, testRuntime, etc. Put a single whitespace line between these
+  blocks.
+- Vulnerability Scanning: Execution of ./gradlew dependencyCheckAnalyze is
+  mandatory upon the addition of any external library to mitigate supply chain
+  risks.
+- Store common configurations in `buildSrc`
 
 ### Licensing Compliance
 
 Authorized licenses for third-party libraries include:
- * Java Standard Library (OpenJDK)
- * BSD, MIT, ISC, Apache 2.0, or EPL.
 
-The use of GPL, AGPL, or LGPLv3+ is prohibited. Utilization of LGPLv2-licensed libraries requires formal review and approval.
+- Java Standard Library (OpenJDK)
+- BSD, MIT, ISC, Apache 2.0, or EPL.
+
+The use of GPL, AGPL, or LGPLv3+ is prohibited. Utilization of LGPLv2-licensed
+libraries requires formal review and approval.
 
 ### Critical Libraries
 
 These are libraries that are basically required from the start of the project.
 
-* The JDK
-* Spotless / Findbugs / ErrorProne / Checker Framework Qual annotations in the build system
-* SLF4J everywhere
-* Vert.x 5
-* Logback in application/server modules 
-* Guice, JSR330 via jakarta annotations
-* Mug 
-* Guava
-* Mockito in tests
-* Junit5 in tests. Do not use JUnit asserts
-* AssertJ in tests, including the module for Guava
-* Cucumber in integration tests
-* Protobuf
-* JSR305
-* ErrorProne Annotations, `mug-errorprone`, Checker Qual annotations, Spotbugs annotations
+- The JDK
+- Spotless / Findbugs / ErrorProne / Checker Framework Qual annotations in the
+  build system
+- SLF4J everywhere
+- Vert.x 5
+- Logback in application/server modules
+- Guice, JSR330 via jakarta annotations
+- Mug
+- Guava
+- Mockito in tests
+- Junit5 in tests. Do not use JUnit asserts
+- AssertJ in tests, including the module for Guava
+- Cucumber in integration tests
+- Protobuf
+- JSR305
+- ErrorProne Annotations, `mug-errorprone`, Checker Qual annotations, Spotbugs
+  annotations
 
 ### Encouraged Libraries
 
-These may be used if the functionality is needed without worrying about the complexity of the import. 
+These may be used if the functionality is needed without worrying about the
+complexity of the import.
 
-* Mug extensions, and in particular `mug-guava` and `mug-concurrent24`
-* Guava, especially if the functionality does not exist in the JDK or in Mug. 
-* Caffeine for caching, if caches are needed. Use this in preference to Guava caches.
-* Apache Commons libraries where the functionality does not exist in Mug, Guava, or the JDK. In particular `io` and `lang3`. Always prefer the implementation in Mug or Guava when one exists in either.
-  * Also worth noting are `csv`, `RDF`, and `text` which may be used if the need comes up. These should always be used in preference to rolling our own implementation of any of the above functionality
-* Guice extensions
-* `dev.cel:cel` if needed for expressions or user-entered "code" that cannot be (or should not be) done declaratively
+- Mug extensions, and in particular `mug-guava` and `mug-concurrent24`
+- Guava, especially if the functionality does not exist in the JDK or in Mug.
+- Caffeine for caching, if caches are needed. Use this in preference to Guava
+  caches.
+- Apache Commons libraries where the functionality does not exist in Mug, Guava,
+  or the JDK. In particular `io` and `lang3`. Always prefer the implementation
+  in Mug or Guava when one exists in either.
+  - Also worth noting are `csv`, `RDF`, and `text` which may be used if the need
+    comes up. These should always be used in preference to rolling our own
+    implementation of any of the above functionality
+- Guice extensions
+- `dev.cel:cel` if needed for expressions or user-entered "code" that cannot be
+  (or should not be) done declaratively

--- a/.agents/skills/guice_di.md
+++ b/.agents/skills/guice_di.md
@@ -1,42 +1,53 @@
 # Skill: Guice Dependency Injection
 
 ## Domain Context
+
 This skill handles working with Guice for dependency injection.
 
 ## Technical Constraints
 
 Guice is the preferred dependency injection framework.
 
-* Always use Guice 7+
-* Dependencies form a directed acyclic graph
-* Favor explicit bindings and declarations
+- Always use Guice 7+
+- Dependencies form a directed acyclic graph
+- Favor explicit bindings and declarations
 
 ## Specific guidance
 
 The following best practices are followed:
 
-* Every package may have exactly one public `Module`. It may have any number of private `Module`s.
-* Do not ever use `com.google.inject.PrivateModule`. Prefer using purpose-built annotations, especially for types that we do not own as part of this project. 
-* Modules may _either_ include other modules _or_ include bindings, never both. When both are needed create a package-protected class that extends `AbstractModule` with the bindings to `install` in the public `Module`.
-* A package's public module should include all of the public modules of immediate subpackages. This should turn the modules into a directed-acyclic-graph of packages.
-* Always use constructor injection and explicit bindings. Do not use `@ImplementedBy`.
-* Prefer creating:
-  * A public interface and a package-protected implementation class, then binding it in a module
-  * A public sealed interface and a package-protected implementation class, then binding it in a module.
-  * A record.
-* Applications (e.g., servers) top level module should always include:
-  * `Modules.requireAtInjectOnConstructorsModule()`
-  * `Modules.disableCircularProxiesModule()`
-  * `Modules.requireExplicitBindingsModule()`
-* Every library should have a single top level `Module` that can be included.
-* Prefer JSR330 annotations or jakarta annotations to guice-specific annotations.
-* Do not use `@Named` annotations and instead use custom annotations.
+- Every package may have exactly one public `Module`. It may have any number of
+  private `Module`s.
+- Do not ever use `com.google.inject.PrivateModule`. Prefer using purpose-built
+  annotations, especially for types that we do not own as part of this project.
+- Modules may _either_ include other modules _or_ include bindings, never both.
+  When both are needed create a package-protected class that extends
+  `AbstractModule` with the bindings to `install` in the public `Module`.
+- A package's public module should include all of the public modules of
+  immediate subpackages. This should turn the modules into a
+  directed-acyclic-graph of packages.
+- Always use constructor injection and explicit bindings. Do not use
+  `@ImplementedBy`.
+- Prefer creating:
+  - A public interface and a package-protected implementation class, then
+    binding it in a module
+  - A public sealed interface and a package-protected implementation class, then
+    binding it in a module.
+  - A record.
+- Applications (e.g., servers) top level module should always include:
+  - `Modules.requireAtInjectOnConstructorsModule()`
+  - `Modules.disableCircularProxiesModule()`
+  - `Modules.requireExplicitBindingsModule()`
+- Every library should have a single top level `Module` that can be included.
+- Prefer JSR330 annotations or jakarta annotations to guice-specific
+  annotations.
+- Do not use `@Named` annotations and instead use custom annotations.
 
 ### Standard Pattern
 
 The standard pattern for a given package is to have **two** modules:
 
-Class 1 is the _binding_ module: 
+Class 1 is the _binding_ module:
 
 ```
 package foo;
@@ -65,4 +76,8 @@ public final class <Foo>Module extends AbstractModule {
 
 It would also install the `<Baz>Module()` from `foo.baz`.
 
-Now, any time you want something bound by `<Foo>BindingModule` the `InstallInstead` annotation prompts you to install `<Foo>Module` instead. This is not automated and must (for now) be manually wired—you need to add the `install()` directive yourself. But once this is done you always default to where `InstallInstead` directs you: to `FooModule()`.
+Now, any time you want something bound by `<Foo>BindingModule` the
+`InstallInstead` annotation prompts you to install `<Foo>Module` instead. This
+is not automated and must (for now) be manually wired—you need to add the
+`install()` directive yourself. But once this is done you always default to
+where `InstallInstead` directs you: to `FooModule()`.

--- a/.agents/skills/java.md
+++ b/.agents/skills/java.md
@@ -1,106 +1,189 @@
 # Skill: Modern Java (JDK 25)
 
 ## Domain Context
+
 This skill handles working in the modern Java 25 environment.
 
 ## Technical Constraints
 
-1. The system is in Java 25 LTS. It uses gradle with the kotlin DSL. Use Java 25 features and avoid legacy constructions such as anonymous inner classes. Use the stream API, lambdas, and a functional style.
-  1. This project has the experimental features enabled. This should be used for the structured concurrency features in Java 25. 
-3. Primary code must be written in Java 21+. Build files must be written in kotlin. Integration tests may be written in gherkin.
+1. The system is in Java 25 LTS. It uses gradle with the kotlin DSL. Use Java 25
+   features and avoid legacy constructions such as anonymous inner classes. Use
+   the stream API, lambdas, and a functional style.
+1. This project has the experimental features enabled. This should be used for
+   the structured concurrency features in Java 25.
+1. Primary code must be written in Java 21+. Build files must be written in
+   kotlin. Integration tests may be written in gherkin.
 
 ## Specific Guidance
 
 ### Core Architectural Principles
- * Type and Null Safety: Developers must prioritize rigorous type safety and the mitigation of null-related vulnerabilities. The use of Optional<T> is mandatory for return types where a value may be absent. Direct invocation of .get() on an Optional instance is prohibited; developers should employ `orElseThrow(Supplier)` or equivalent safe-access patterns. Assume values that are not annotated as `Nullable` or explicitly contracted as such in some other way are non-null by default.
- * Modern Java Implementation: All source code shall target JDK 21 or later. Implementation should leverage contemporary features, specifically Records for immutable data carriers, Sealed Classes and Interfaces for restricted type hierarchies, and Pattern Matching within switch expressions to enhance code clarity and exhaustive analysis.
- * Modular Maintainability: Method definitions should remain concise and specialized. Adherence to SOLID design principles is required to facilitate long-term maintainability and codebase scalability.
- * Concurrent Performance: For high-concurrency and I/O-intensive operations, the use of Virtual Threads (Project Loom) is the preferred standard. This approach ensures optimal resource utilization and high throughput without the overhead associated with traditional platform threads.
+
+- Type and Null Safety: Developers must prioritize rigorous type safety and the
+  mitigation of null-related vulnerabilities. The use of Optional<T> is
+  mandatory for return types where a value may be absent. Direct invocation of
+  .get() on an Optional instance is prohibited; developers should employ
+  `orElseThrow(Supplier)` or equivalent safe-access patterns. Assume values that
+  are not annotated as `Nullable` or explicitly contracted as such in some other
+  way are non-null by default.
+- Modern Java Implementation: All source code shall target JDK 21 or later.
+  Implementation should leverage contemporary features, specifically Records for
+  immutable data carriers, Sealed Classes and Interfaces for restricted type
+  hierarchies, and Pattern Matching within switch expressions to enhance code
+  clarity and exhaustive analysis.
+- Modular Maintainability: Method definitions should remain concise and
+  specialized. Adherence to SOLID design principles is required to facilitate
+  long-term maintainability and codebase scalability.
+- Concurrent Performance: For high-concurrency and I/O-intensive operations, the
+  use of Virtual Threads (Project Loom) is the preferred standard. This approach
+  ensures optimal resource utilization and high throughput without the overhead
+  associated with traditional platform threads.
 
 ### Guava
 
-Guava utilities are explicitly allowed in the system and preferred to Apache Commons utilities where available. Use context7 to get the latest documentation.
+Guava utilities are explicitly allowed in the system and preferred to Apache
+Commons utilities where available. Use context7 to get the latest documentation.
 
-* Use Guava when there is not a similar piece of functionality in the JDK (e.g., use the JDK `Optional`, not the Guava equivalent). Exceptions include: Joiner, `io`, and immutable collections, which should always be used in preference to similar tools elsewhere.
-* Do not use `@Deprecated` components unless absolutely necessary and document why they are necessary if they must be used.
-* Do not use `@Beta` components in the library modules. They _may_ be used anywhere in testing as well as in the application components (repl and batch).
+- Use Guava when there is not a similar piece of functionality in the JDK (e.g.,
+  use the JDK `Optional`, not the Guava equivalent). Exceptions include: Joiner,
+  `io`, and immutable collections, which should always be used in preference to
+  similar tools elsewhere.
+- Do not use `@Deprecated` components unless absolutely necessary and document
+  why they are necessary if they must be used.
+- Do not use `@Beta` components in the library modules. They _may_ be used
+  anywhere in testing as well as in the application components (repl and batch).
 
 exercised.
 
 ### Implementation Directives
 
- * Immutability: Immutability is the default preference. Developers should utilize Records and declare variables as final whenever feasible.
-   * Use `ImmutableList`, `ImmutableSet`, etc whenever possible. Prefer creating new objects to updating old ones.
- * Classes should be either abstract or final where possible. Package protected should be the default for classes, with any exposure of their functionality done through an interface with Guice.
- * Avoid static methods.
- * Strongly prefer static inner classes where inner classes are used.
- * Include a `package-info.java` file in every package with a public object in it.
- * Functional programming: Prefer `streaming` interfaces, closures, and functional patterns. 
- * Asynchronous Processing: Virtual threads should be leveraged for I/O operations to maintain system responsiveness and throughput. Avoid synchronized blocks or heavy ThreadLocals that can lead to 'pinning' of virtual threads; prefer ReentrantLocks where necessary. Avoid the use of `Thread` directly and use listening thread pools from guava if non-virtual threads are needed. 
- * Exceptional Circumstances:
-   * Unchecked exceptions are appropriate for critical application-level failures.
-   * Custom checked exceptions should be utilized for domain-specific errors that allow for recovery.
-   * Fault Tolerance: Background processes must implement robust error handling to prevent silent thread termination.
- * Domain Modeling: Utilize Sealed Interfaces and Records to model domain states precisely. This approach minimizes "primitive obsession" by encapsulating data within contextually meaningful types. Avoid "stringly typed" systems and use enums or records as appropriat.
- * Logging
-   * Always log error messages. Do not ever `printStackTrace`.
-   * Do not ignore exceptions. If they are truly trivial they can be logged at a debug level, or a comment can be inserted indicating that the exception cannot happen.
+- Immutability: Immutability is the default preference. Developers should
+  utilize Records and declare variables as final whenever feasible.
+  - Use `ImmutableList`, `ImmutableSet`, etc whenever possible. Prefer creating
+    new objects to updating old ones.
+- Classes should be either abstract or final where possible. Package protected
+  should be the default for classes, with any exposure of their functionality
+  done through an interface with Guice.
+- Avoid static methods.
+- Strongly prefer static inner classes where inner classes are used.
+- Include a `package-info.java` file in every package with a public object in
+  it.
+- Functional programming: Prefer `streaming` interfaces, closures, and
+  functional patterns.
+- Asynchronous Processing: Virtual threads should be leveraged for I/O
+  operations to maintain system responsiveness and throughput. Avoid
+  synchronized blocks or heavy ThreadLocals that can lead to 'pinning' of
+  virtual threads; prefer ReentrantLocks where necessary. Avoid the use of
+  `Thread` directly and use listening thread pools from guava if non-virtual
+  threads are needed.
+- Exceptional Circumstances:
+  - Unchecked exceptions are appropriate for critical application-level
+    failures.
+  - Custom checked exceptions should be utilized for domain-specific errors that
+    allow for recovery.
+  - Fault Tolerance: Background processes must implement robust error handling
+    to prevent silent thread termination.
+- Domain Modeling: Utilize Sealed Interfaces and Records to model domain states
+  precisely. This approach minimizes "primitive obsession" by encapsulating data
+  within contextually meaningful types. Avoid "stringly typed" systems and use
+  enums or records as appropriat.
+- Logging
+  - Always log error messages. Do not ever `printStackTrace`.
+  - Do not ignore exceptions. If they are truly trivial they can be logged at a
+    debug level, or a comment can be inserted indicating that the exception
+    cannot happen.
 
 happen.
 
 ### Java Style
 
-* When there only exists a single implementation for a java interface or abstract class, that class may be named `Default<InterfaceName>`. It should never be named `InterfaceNameImpl`.
-* Interfaces should just be the interface name and not include any marking in the name indicating that they are an interface (so `Example` not `IExample` or `ExampleInterface`).
-* Classes should be package protected. If they need to be used outside of the class there should be a guice binding to an interface and/or a factory. If they are public they should _always_ be final.
-* Classes should be either abstract or final.
-* Abstract classes should be named `Abstract<ClassName>`. They should typically be package protected.
-* Thread safety should always be documented using JSR305 annotations.
-* For non-record classes: Prefer using factories or factory methods to using `new <ClassName>(<args>)`. The best case is to inject them with guice.
-* Dependencies may only reach _down_ or _out_ in the package hierarchy. They may not reach directly _up_. So `x.y` may depend on other classes in `x.y`, `x.y.z`, `x.p`, or `x.p.q.r`, but never on classes in `x` proper.
-* Dependencies may never be circular between packages. If `x.y` depends on `x.p.q.r` then `x.p.q.r` cannot depend on anything in `x.y`.
-* Tests should be named `<ClassName>[OptionalTestType]Test`. If it is a test of a "default" implementation it should be named `<InterfaceName>Test`. `OptionalTestType` may be used for, e.g., performance or integration tests, but should not be used to mark just plain unit tests. Example test types:
-  * None. The default. `FooTest`
-  * Integration. `FooIntegrationTest`, typically written with cucumber, though may be written with other tooling.
-  * Performance. `FooPerformanceTest`, used to check for performance regressions. Should typically use Gatling or the Java Microbenchmark Harness.
+- When there only exists a single implementation for a java interface or
+  abstract class, that class may be named `Default<InterfaceName>`. It should
+  never be named `InterfaceNameImpl`.
+- Interfaces should just be the interface name and not include any marking in
+  the name indicating that they are an interface (so `Example` not `IExample` or
+  `ExampleInterface`).
+- Classes should be package protected. If they need to be used outside of the
+  class there should be a guice binding to an interface and/or a factory. If
+  they are public they should _always_ be final.
+- Classes should be either abstract or final.
+- Abstract classes should be named `Abstract<ClassName>`. They should typically
+  be package protected.
+- Thread safety should always be documented using JSR305 annotations.
+- For non-record classes: Prefer using factories or factory methods to using
+  `new <ClassName>(<args>)`. The best case is to inject them with guice.
+- Dependencies may only reach _down_ or _out_ in the package hierarchy. They may
+  not reach directly _up_. So `x.y` may depend on other classes in `x.y`,
+  `x.y.z`, `x.p`, or `x.p.q.r`, but never on classes in `x` proper.
+- Dependencies may never be circular between packages. If `x.y` depends on
+  `x.p.q.r` then `x.p.q.r` cannot depend on anything in `x.y`.
+- Tests should be named `<ClassName>[OptionalTestType]Test`. If it is a test of
+  a "default" implementation it should be named `<InterfaceName>Test`.
+  `OptionalTestType` may be used for, e.g., performance or integration tests,
+  but should not be used to mark just plain unit tests. Example test types:
+  - None. The default. `FooTest`
+  - Integration. `FooIntegrationTest`, typically written with cucumber, though
+    may be written with other tooling.
+  - Performance. `FooPerformanceTest`, used to check for performance
+    regressions. Should typically use Gatling or the Java Microbenchmark
+    Harness.
 
 tests.
 
 ### Logging with SLF4J
 
-* Every class that is going to be doing logging should have a `private final Logger` at the top of the class declaration, taking the class as the argument for the `LoggerFactory` to produce the logger.
-* `fatal` is for logs surrounding the unexpected death of the process. 
-* `error` is for logs where there was a compromise in the integrity of the system in some way. This includes crashes, data corruption, etc. This includes situations where a major feature is broken or unusable. 
-* `warn` is for logs where there is an exception or error of some sort that is not expected and that needs to be corrected, but which may represent a transient failure.
-* `info` is for logs that represent the progress of the application. Especially in batch mode.
-* `debug` is for logs useful for debugging but that will be disabled at runtime.
-* `trace` is for extremely fine-grained logs that are needed for debugging but won't even be turned on for casual users. Complex log messages in tight loops, for example.
-* `Marker`s may be used for cross-cutting concerns. Specifically useful for:
-  * Logs reporting on the application configuration
-  * Initialization and shutdown logs
+- Every class that is going to be doing logging should have a
+  `private final Logger` at the top of the class declaration, taking the class
+  as the argument for the `LoggerFactory` to produce the logger.
+- `fatal` is for logs surrounding the unexpected death of the process.
+- `error` is for logs where there was a compromise in the integrity of the
+  system in some way. This includes crashes, data corruption, etc. This includes
+  situations where a major feature is broken or unusable.
+- `warn` is for logs where there is an exception or error of some sort that is
+  not expected and that needs to be corrected, but which may represent a
+  transient failure.
+- `info` is for logs that represent the progress of the application. Especially
+  in batch mode.
+- `debug` is for logs useful for debugging but that will be disabled at runtime.
+- `trace` is for extremely fine-grained logs that are needed for debugging but
+  won't even be turned on for casual users. Complex log messages in tight loops,
+  for example.
+- `Marker`s may be used for cross-cutting concerns. Specifically useful for:
+  - Logs reporting on the application configuration
+  - Initialization and shutdown logs
 
 ### Libraries
 
-The following libraries may be included without hesitation and their functionality should be employed freely.
+The following libraries may be included without hesitation and their
+functionality should be employed freely.
 
-* ErrorProne Annotations, `mug-errorprone`
-* Any of the vert.x 5 libraries. Use context7 to get the most recent documentation on these when you use them.
-* Mug and Mug extensions, and in particular `mug-guava`, `dot-parse`, and `mug-concurrent24`
-* Guava, especially if the functionality does not exist in the JDK or in Mug. In particular, the following should be used whenever possible:
-  * Immutable collections, Joiner, and Splitter.
-  * `com.google.common.io`
-  * `com.google.common.graph`
-* Caffeine for caching, if caches are needed. Use this in preference to Guava caches.
-* Apache Commons libraries where the functionality does not exist in Mug, Guava, or the JDK. In particular `io` and `lang3`. Always prefer the implementation in Mug or Guava when one exists in either.
-  * Also worth noting are `csv`, `RDF`, and `text` which may be used if the need comes up. These should always be used in preference to rolling our own implementation of any of the above functionality
-* `dev.cel:cel` if needed for expressions or user-entered "code" that cannot be (or should not be) done declaratively
- 
+- ErrorProne Annotations, `mug-errorprone`
+- Any of the vert.x 5 libraries. Use context7 to get the most recent
+  documentation on these when you use them.
+- Mug and Mug extensions, and in particular `mug-guava`, `dot-parse`, and
+  `mug-concurrent24`
+- Guava, especially if the functionality does not exist in the JDK or in Mug. In
+  particular, the following should be used whenever possible:
+  - Immutable collections, Joiner, and Splitter.
+  - `com.google.common.io`
+  - `com.google.common.graph`
+- Caffeine for caching, if caches are needed. Use this in preference to Guava
+  caches.
+- Apache Commons libraries where the functionality does not exist in Mug, Guava,
+  or the JDK. In particular `io` and `lang3`. Always prefer the implementation
+  in Mug or Guava when one exists in either.
+  - Also worth noting are `csv`, `RDF`, and `text` which may be used if the need
+    comes up. These should always be used in preference to rolling our own
+    implementation of any of the above functionality
+- `dev.cel:cel` if needed for expressions or user-entered "code" that cannot be
+  (or should not be) done declaratively
+
 ## Antipatterns
 
-This table contans a list of patterns to avoid, as well as the alternative to prefer instead:
+This table contans a list of patterns to avoid, as well as the alternative to
+prefer instead:
 
 | Instead of                              | Do this                              | Justification                                |
-| ----------------------------------------|--------------------------------------|--------------------------------------------- |
+| --------------------------------------- | ------------------------------------ | -------------------------------------------- |
 | `Optional.get()`                        | `Optional.orElseThrow(Supplier)`     | Throw a customized exception from a supplier |
 | `synchronized`                          | `ReentrantLock`                      | Avoid pinning for virtual threads            |
 | `new ArrayList<T>()`                    | `ImmutableList.builder()`            | End result is immutable                      |
@@ -116,7 +199,7 @@ This table contans a list of patterns to avoid, as well as the alternative to pr
 | `PrivateModule`                         | Use a custom qualifier annotation    | Easier to debug and reason about             |
 | `method(arg1, inOutParameter)`          | `var retval = method(arg1)`          | Prefer modern java idioms                    |
 
-
 ## Miscellaneous
 
-* When it is not contradicted by other instructions, use the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
+- When it is not contradicted by other instructions, use the
+  [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).

--- a/.agents/skills/markdown.md
+++ b/.agents/skills/markdown.md
@@ -6,17 +6,24 @@ This skill handles the creation of markdown documents to document the system.
 
 ## Technical Constraints
 
-1. Markdown files are stored in `docs/` but may be placed inside of subdirectories.
-2. Markdown files are properly formatted using a structured document format (so favoring headers to represent document structure).
+1. Markdown files are stored in `docs/` but may be placed inside of
+   subdirectories.
+2. Markdown files are properly formatted using a structured document format (so
+   favoring headers to represent document structure).
 3. Write at a 10th—12th grade level.
-4. Assume a knowledge base of a person with a bachelors-level understanding of of theoretical computer science and a familiarity with LARP concepts.
+4. Assume a knowledge base of a person with a bachelors-level understanding of
+   of theoretical computer science and a familiarity with LARP concepts.
 5. Limit line length to 100 characters.
-6. Unless otherwise directed the ideal document length is around 512±128 words. This does not apply to code, typeset mathematics, or mermaid.js diagrams that may be included.
+6. Unless otherwise directed the ideal document length is around 512±128 words.
+   This does not apply to code, typeset mathematics, or mermaid.js diagrams that
+   may be included.
 
 ## Specific Guidance
 
-* Load documentation from the GitHub Flavored Markdown Spec on context7.
-* Prefer that pseudocode be written in mathematical pseudocode. If that is not possible, then use Java.
-* Use mermaid.js for diagrams. Load the mermaid.js documentation from context7.
-* Files should always be UTF-8
-* Try to break up large amounts of text with bullet points, code snippets, multiple sections, or diagrams.
+- Load documentation from the GitHub Flavored Markdown Spec on context7.
+- Prefer that pseudocode be written in mathematical pseudocode. If that is not
+  possible, then use Java.
+- Use mermaid.js for diagrams. Load the mermaid.js documentation from context7.
+- Files should always be UTF-8
+- Try to break up large amounts of text with bullet points, code snippets,
+  multiple sections, or diagrams.

--- a/.agents/skills/testing.md
+++ b/.agents/skills/testing.md
@@ -1,49 +1,83 @@
 # Skill: Testing
 
 ## Domain Context
+
 This skill handles writing tests.
 
 ## Technical Constraints
 
-* Tests are written with JUnit5, AssertJ, and Mockito. They optionally (in `:integration`) use cucumber
-* 100% branch coverage is required in testing
-* `:test` contains centralized test logic and dependencies, `:integration` contains integration tests.
-* Tests should be named `<ClassName>[OptionalTestType]Test`. If it is a test of a "default" implementation it should be named `<InterfaceName>Test`. `OptionalTestType` may be used for, e.g., performance or integration tests, but should not be used to mark just plain unit tests.
+- Tests are written with JUnit5, AssertJ, and Mockito. They optionally (in
+  `:integration`) use cucumber
+- 100% branch coverage is required in testing
+- `:test` contains centralized test logic and dependencies, `:integration`
+  contains integration tests.
+- Tests should be named `<ClassName>[OptionalTestType]Test`. If it is a test of
+  a "default" implementation it should be named `<InterfaceName>Test`.
+  `OptionalTestType` may be used for, e.g., performance or integration tests,
+  but should not be used to mark just plain unit tests.
 
 ## Specific guidance
 
 ### Testing Protocols
 
- * Test-Driven Development (TDD): The adoption of TDD is strongly encouraged. Developers should implement tests prior to writing functional code to ensure requirement alignment and incremental progress.
- * Unit Testing: JUnit 5 and AssertJ are the standard frameworks for unit verification. Test classes must be located in `<module>/src/test/java` and follow the package structure of the target source.
- * Integration Testing: Cucumber shall be employed for behavior-driven development (BDD) scenarios. For tests requiring external infrastructure, such as databases, Testcontainers is the required solution. Integration tests written with cucumber may be included in the `:integration:` module.
- * Regression and Snapshot Testing: Selfie is used for verifying CLI output and parser state. Updates to snapshots must be explicitly reviewed before acceptance. Snapshot changes must be committed in the same PR as the logic change, and the commit message must explicitly acknowledge the output delta.
- * Coverage: Write the tests alongside the code. Every branch (if/else) must be exercised.
+- Test-Driven Development (TDD): The adoption of TDD is strongly encouraged.
+  Developers should implement tests prior to writing functional code to ensure
+  requirement alignment and incremental progress.
+- Unit Testing: JUnit 5 and AssertJ are the standard frameworks for unit
+  verification. Test classes must be located in `<module>/src/test/java` and
+  follow the package structure of the target source.
+- Integration Testing: Cucumber shall be employed for behavior-driven
+  development (BDD) scenarios. For tests requiring external infrastructure, such
+  as databases, Testcontainers is the required solution. Integration tests
+  written with cucumber may be included in the `:integration:` module.
+- Regression and Snapshot Testing: Selfie is used for verifying CLI output and
+  parser state. Updates to snapshots must be explicitly reviewed before
+  acceptance. Snapshot changes must be committed in the same PR as the logic
+  change, and the commit message must explicitly acknowledge the output delta.
+- Coverage: Write the tests alongside the code. Every branch (if/else) must be
+  exercised.
 
 ### Unit Tests
 
-* Name unit tests with osgrove's test name pattern: `<method>_<what is being tested>_<expected outcome>`. If the name is going to be longer than 90 characters then use abbreviations and omit assumed words (e.g., `return` in the `<expected outcome>`) to reduce the length and add a `@DisplayName`.
-* Unit tests should aim to test one thing per `@Test`. 
-* Use AssertJ. Matchers should be implemented to minimize the number of assertions per test, with one assert per test being the goal.
-* Avoid reflection in tests. Never, ever use reflection for construction of objects.
-* Focus on behavior verification.
-* Testing by injecting the public guice modules is preferable when such is an option.
-* Aim for tests to test a single thing per test. Where possible, use only a single assert per test, and use AssertJ's features to be able to test complex objects.
-* Test names should be terse and precise as to what is being tested. Avoid saying "is correct" in favor of saying what is correct/expected.
-* This project enforces (via jacoco) extremely high testing requirements across both the instructions that are tested as well as ensuring that the branches are covered. Always design with testability in mind and make sure things are thoroughly tested.
-
+- Name unit tests with osgrove's test name pattern:
+  `<method>_<what is being tested>_<expected outcome>`. If the name is going to
+  be longer than 90 characters then use abbreviations and omit assumed words
+  (e.g., `return` in the `<expected outcome>`) to reduce the length and add a
+  `@DisplayName`.
+- Unit tests should aim to test one thing per `@Test`.
+- Use AssertJ. Matchers should be implemented to minimize the number of
+  assertions per test, with one assert per test being the goal.
+- Avoid reflection in tests. Never, ever use reflection for construction of
+  objects.
+- Focus on behavior verification.
+- Testing by injecting the public guice modules is preferable when such is an
+  option.
+- Aim for tests to test a single thing per test. Where possible, use only a
+  single assert per test, and use AssertJ's features to be able to test complex
+  objects.
+- Test names should be terse and precise as to what is being tested. Avoid
+  saying "is correct" in favor of saying what is correct/expected.
+- This project enforces (via jacoco) extremely high testing requirements across
+  both the instructions that are tested as well as ensuring that the branches
+  are covered. Always design with testability in mind and make sure things are
+  thoroughly tested.
 
 ### Integration Tests
 
-* Integration tests are written with cucumber and stored in `:integration`
+- Integration tests are written with cucumber and stored in `:integration`
 
 ### Troubleshooting Inadequate Coverage
 
-This project has a very high branch and line coverage requirement that is sometimes difficult to reach.
+This project has a very high branch and line coverage requirement that is
+sometimes difficult to reach.
 
 Strategies you can use:
 
-* Remove unreachable code unless the compiler requires you to have it
-* Break methods down into smaller `private` units.
-* Take smaller `private` methods out and create a new `class` with them. You can make this class package private or you can bind it with an interface. Either way, put it in the local binding module and then inject it.
-* If you need to mock something but can't because it is `final` or because its constructor is package private, then create an interface for it, bind it in Guice, and then use Guice to inject it.
+- Remove unreachable code unless the compiler requires you to have it
+- Break methods down into smaller `private` units.
+- Take smaller `private` methods out and create a new `class` with them. You can
+  make this class package private or you can bind it with an interface. Either
+  way, put it in the local binding module and then inject it.
+- If you need to mock something but can't because it is `final` or because its
+  constructor is package private, then create an interface for it, bind it in
+  Guice, and then use Guice to inject it.

--- a/.agents/skills/vertx.md
+++ b/.agents/skills/vertx.md
@@ -1,71 +1,117 @@
 # Skill: Vert.x 5 Reactive Development
 
 ## Domain Context
-This skill extends the core Java development guidelines to handle reactive, non-blocking, and high-performance applications specifically utilizing the Vert.x 5 toolkit. 
+
+This skill extends the core Java development guidelines to handle reactive,
+non-blocking, and high-performance applications specifically utilizing the
+Vert.x 5 toolkit.
 
 ## Technical Constraints
 
-1. Vert.x 5 is the core framework. Always utilize the asynchronous and reactive paradigms native to Vert.x unless explicitly operating within a designated blocking context (e.g., using `vertx.executeBlocking()`).
+1. Vert.x 5 is the core framework. Always utilize the asynchronous and reactive
+   paradigms native to Vert.x unless explicitly operating within a designated
+   blocking context (e.g., using `vertx.executeBlocking()`).
 
 ## Specific Guidance
 
 ### Core Architectural Principles
- * **Non-Blocking Default:** The primary rule of Vert.x is never to block the Event Loop. CPU-intensive tasks or blocking I/O must be delegated to worker threads or Virtual Threads.
- * **Event-Driven Communication:** Components should communicate primarily via message-passing over the Vert.x EventBus. This guarantees loose coupling and facilitates seamless scaling from single-node to distributed systems.
- * **Virtual Thread Integration:** Vert.x 5 has deep integration with Project Loom. For complex asynchronous orchestration that is hard to read with `Future` composition, prefer deploying Virtual Thread Verticles to maintain straight-line, readable code without sacrificing concurrency.
- * **Security & Resilience:** Assume network unreliability for distributed Vert.x applications. Always implement timeouts on asynchronous operations, use circuit breakers for external service calls, and ensure clustered EventBus communication is secured via TLS.
+
+- **Non-Blocking Default:** The primary rule of Vert.x is never to block the
+  Event Loop. CPU-intensive tasks or blocking I/O must be delegated to worker
+  threads or Virtual Threads.
+- **Event-Driven Communication:** Components should communicate primarily via
+  message-passing over the Vert.x EventBus. This guarantees loose coupling and
+  facilitates seamless scaling from single-node to distributed systems.
+- **Virtual Thread Integration:** Vert.x 5 has deep integration with Project
+  Loom. For complex asynchronous orchestration that is hard to read with
+  `Future` composition, prefer deploying Virtual Thread Verticles to maintain
+  straight-line, readable code without sacrificing concurrency.
+- **Security & Resilience:** Assume network unreliability for distributed Vert.x
+  applications. Always implement timeouts on asynchronous operations, use
+  circuit breakers for external service calls, and ensure clustered EventBus
+  communication is secured via TLS.
 
 ### Initialization
 
-Initialization of the application Vert.x should be delayed until after the Guice injector has been fully created. 
+Initialization of the application Vert.x should be delayed until after the Guice
+injector has been fully created.
 
 ### Context7 Directives
 
-Always query `Context7` for the most up-to-date Vert.x 5 API documentation, paying special attention to shifts from Vert.x 4 (e.g., deeper Loom integration, SQL client changes, and web routing enhancements).  Load sub-modules as appropriate (e.g., Vert.x Web when working with `vertx-web`).
+Always query `Context7` for the most up-to-date Vert.x 5 API documentation,
+paying special attention to shifts from Vert.x 4 (e.g., deeper Loom integration,
+SQL client changes, and web routing enhancements). Load sub-modules as
+appropriate (e.g., Vert.x Web when working with `vertx-web`).
 
 ### Implementation Directives
 
- * **Verticle Design:** Verticles should be small, focused, and adhere to the Single Responsibility Principle. They must hold their own local state and avoid shared mutable data structures with other Verticles.
- * **State Management:** If state must be shared, utilize Vert.x Local/Cluster Maps or asynchronous data stores. Do not use standard `java.util.concurrent` locks or `synchronized` blocks within an Event Loop context.
- * **Asynchronous Composition:** When not using Virtual Threads, avoid "callback hell" by strictly using `Future.map()`, `Future.compose()`, and `Future.all()` / `Future.any()` for coordinating multiple asynchronous operations. Do not wrap Vert.x APIs in `java.util.concurrent.CompletableFuture` unless interoperating with an external library.
- * **Immutability on the EventBus:** Messages passed over the EventBus must be immutable. Use Java Records or protobuf for custom message codecs and data transfer objects (DTOs).
- * **Routing & Web:** When using Vert.x Web, modularize routes using sub-routers. Always implement global error handlers to catch and format exceptions escaping from route handlers.
- * **Database Access:** Utilize the Vert.x Reactive SQL Clients (e.g., `vertx-pg-client`). JDBC should only be used if wrapped in a worker tier or Virtual Thread, and only if a reactive driver does not exist for the target datastore.
- * **Prefer Vert.x Libraries:** If there is a vert.x solution for something (e.g., OpenAPI integration) that should be used in preference to rolling our own. 
+- **Verticle Design:** Verticles should be small, focused, and adhere to the
+  Single Responsibility Principle. They must hold their own local state and
+  avoid shared mutable data structures with other Verticles.
+- **State Management:** If state must be shared, utilize Vert.x Local/Cluster
+  Maps or asynchronous data stores. Do not use standard `java.util.concurrent`
+  locks or `synchronized` blocks within an Event Loop context.
+- **Asynchronous Composition:** When not using Virtual Threads, avoid "callback
+  hell" by strictly using `Future.map()`, `Future.compose()`, and `Future.all()`
+  / `Future.any()` for coordinating multiple asynchronous operations. Do not
+  wrap Vert.x APIs in `java.util.concurrent.CompletableFuture` unless
+  interoperating with an external library.
+- **Immutability on the EventBus:** Messages passed over the EventBus must be
+  immutable. Use Java Records or protobuf for custom message codecs and data
+  transfer objects (DTOs).
+- **Routing & Web:** When using Vert.x Web, modularize routes using sub-routers.
+  Always implement global error handlers to catch and format exceptions escaping
+  from route handlers.
+- **Database Access:** Utilize the Vert.x Reactive SQL Clients (e.g.,
+  `vertx-pg-client`). JDBC should only be used if wrapped in a worker tier or
+  Virtual Thread, and only if a reactive driver does not exist for the target
+  datastore.
+- **Prefer Vert.x Libraries:** If there is a vert.x solution for something
+  (e.g., OpenAPI integration) that should be used in preference to rolling our
+  own.
 
 ### Vert.x Style
 
-* Custom EventBus message codecs should be named `<RecordName>MessageCodec` and bound during application initialization.
-* Verticle classes should be suffixed with `Verticle` (e.g., `HttpServerVerticle`, `DataProcessingVerticle`).
-* Testing must heavily leverage `vertx-junit5`. Tests requiring asynchronous resolution should use `VertxTestContext` to await completion, preventing premature test termination.
+- Custom EventBus message codecs should be named `<RecordName>MessageCodec` and
+  bound during application initialization.
+- Verticle classes should be suffixed with `Verticle` (e.g.,
+  `HttpServerVerticle`, `DataProcessingVerticle`).
+- Testing must heavily leverage `vertx-junit5`. Tests requiring asynchronous
+  resolution should use `VertxTestContext` to await completion, preventing
+  premature test termination.
 
 ### Contextual Logging
 
-* Standard MDC (Mapped Diagnostic Context) often fails across thread context switches in asynchronous environments. Ensure trace IDs are explicitly passed or use Vert.x's specific context-aware logging extensions when tracing across EventBus boundaries.
+- Standard MDC (Mapped Diagnostic Context) often fails across thread context
+  switches in asynchronous environments. Ensure trace IDs are explicitly passed
+  or use Vert.x's specific context-aware logging extensions when tracing across
+  EventBus boundaries.
 
 ### Vert.x Libraries
 
 The following ecosystem libraries should be used for their respective domains:
-* **Vert.x Core & Extensions:**
-  * `vertx-core`
-  * `vertx-web`
-  * `vertx-config`
-  * `vertx-health-check`
-* **System Design:** `vertx-service-discovery`
-* **Data Access:** `vertx-pg-client`
-* **Authentication and Authorization:** `vertx-auth-common`
-* **Testing:** `vertx-junit5`, `vertx-web-client`
-* **Data Serialization:** Use Jackson (integrated into Vert.x) combined with Java Records or protobuf (included in `:proto`) via the protobuf handler we've registered.
+
+- **Vert.x Core & Extensions:**
+  - `vertx-core`
+  - `vertx-web`
+  - `vertx-config`
+  - `vertx-health-check`
+- **System Design:** `vertx-service-discovery`
+- **Data Access:** `vertx-pg-client`
+- **Authentication and Authorization:** `vertx-auth-common`
+- **Testing:** `vertx-junit5`, `vertx-web-client`
+- **Data Serialization:** Use Jackson (integrated into Vert.x) combined with
+  Java Records or protobuf (included in `:proto`) via the protobuf handler we've
+  registered.
 
 ## Antipatterns
 
-| Instead of                              | Do this                                      | Justification                                                |
-| --------------------------------------- | -------------------------------------------- | ------------------------------------------------------------ |
-| `Thread.sleep(...)`                     | `vertx.setTimer(..., handler)`               | `Thread.sleep` blocks the Event Loop, halting the system.    |
-| Nested Callbacks (`handler(res -> {})`) | `Future.compose()` or Virtual Threads        | Prevents callback hell and maintains code maintainability.   |
-| Standard JDBC drivers                   | Vert.x Reactive SQL Clients                  | Reactive clients do not block threads while awaiting I/O.    |
-| Shared `HashMap` between Verticles      | EventBus or `SharedData` maps                | Enforces thread safety without blocking synchronization.     |
-| `CompletableFuture.supplyAsync()`       | `vertx.executeBlocking()`                    | Keeps blocking tasks managed within Vert.x worker pools.     |
-| Manual JSON parsing/building            | `JsonObject.mapFrom()` with Java Records     | Reduces boilerplate and leverages built-in Jackson mapping.  |
-| Try/Catch around async operations       | `.onFailure(...)` on the `Future`            | Standard try/catch blocks do not catch async exceptions.     |
-
+| Instead of                              | Do this                                  | Justification                                               |
+| --------------------------------------- | ---------------------------------------- | ----------------------------------------------------------- |
+| `Thread.sleep(...)`                     | `vertx.setTimer(..., handler)`           | `Thread.sleep` blocks the Event Loop, halting the system.   |
+| Nested Callbacks (`handler(res -> {})`) | `Future.compose()` or Virtual Threads    | Prevents callback hell and maintains code maintainability.  |
+| Standard JDBC drivers                   | Vert.x Reactive SQL Clients              | Reactive clients do not block threads while awaiting I/O.   |
+| Shared `HashMap` between Verticles      | EventBus or `SharedData` maps            | Enforces thread safety without blocking synchronization.    |
+| `CompletableFuture.supplyAsync()`       | `vertx.executeBlocking()`                | Keeps blocking tasks managed within Vert.x worker pools.    |
+| Manual JSON parsing/building            | `JsonObject.mapFrom()` with Java Records | Reduces boilerplate and leverages built-in Jackson mapping. |
+| Try/Catch around async operations       | `.onFailure(...)` on the `Future`        | Standard try/catch blocks do not catch async exceptions.    |

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,9 +1,10 @@
-
-
-----
+---
 
 ## 🤖 Generative AI Disclosure
-> [!IMPORTANT]
-> This project has a **ZERO TOLERANCE** policy for undisclosed AI contributions. Failure to complete this section accurately may result in immediate rejection or being banned from the project
 
-**Note:** By submitting this PR, you acknowledge responsibility for the code under your name per the project's Accountability policy.
+> [!IMPORTANT] This project has a **ZERO TOLERANCE** policy for undisclosed AI
+> contributions. Failure to complete this section accurately may result in
+> immediate rejection or being banned from the project
+
+**Note:** By submitting this PR, you acknowledge responsibility for the code
+under your name per the project's Accountability policy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,87 +2,143 @@
 
 # Java Project Development Guidelines: Technical Standards and Best Practices
 
-You are a Senior Java engineer working on the project `metonomy`. To maintain modularity, your technical capabilities are partitioned into "skills":
+You are a Senior Java engineer working on the project `metonomy`. To maintain
+modularity, your technical capabilities are partitioned into "skills":
 
-* **Discovery**: Upon initialization, you must read `.agents/SKILLS.md` to identify active capabilities. You must then load the file you are directed to based on the capabilities you need for a given project. When you use a skill, add it's name to your commit message.
-* **Delegation**: When a task falls within a skill's domain, defer to the specific constraints in that module.
-* **Conflicts**: If a skill constraint conflicts with a core `AGENTS.md` rule, the specific skill constraint takes precedence.
+- **Discovery**: Upon initialization, you must read `.agents/SKILLS.md` to
+  identify active capabilities. You must then load the file you are directed to
+  based on the capabilities you need for a given project. When you use a skill,
+  add it's name to your commit message.
+- **Delegation**: When a task falls within a skill's domain, defer to the
+  specific constraints in that module.
+- **Conflicts**: If a skill constraint conflicts with a core `AGENTS.md` rule,
+  the specific skill constraint takes precedence.
 
 ## Key Points
 
-* Always check `.agents/SKILLS.md` at the start of a task and load the relevant skill files. Load relevant skill files as you need them or if you anticipate needing them.
-* This is a Java 25 project that uses Java 25 idioms and features. Including but not limited to virtual threads, the streaming api, sealed interfaces, and record classes. The structured concurrency experiment is enabled and free to use as well. use context7 to get the documentation for JDK 25.
-  * Use records for data carriers and sealed interfaces for closed hierarchies
-  * Always prefer `ImmutableList.of()`, `ImmutableList.builder()`, or `stream().collect(ImmutableList.toImmutableList())`
-  * Address all warnings immediately. Use `@SuppressWarnings` only as a last resort and *always* with a justifying comment
-* 100% branch coverage is required in testing. Testing is based on JUnit 5, AssertJ, and Cucumber.
-* This is a Gradle project using the Kotlin DSL. Do not use groovy.
-* This is a high complexity project that demands adherence to rigid coding standards and makes heavy use of abstractions.
-  * Run `./gradlew spotlessApply` before every commit or check
-  * Read the error messages carefully. They usually point to specific style violations or potential bugs
-* This is a system that values correctness, completeness, and flexibility.
-* Vert.x is the base build system. Injection is handled by Guice.
+- Always check `.agents/SKILLS.md` at the start of a task and load the relevant
+  skill files. Load relevant skill files as you need them or if you anticipate
+  needing them.
+- This is a Java 25 project that uses Java 25 idioms and features. Including but
+  not limited to virtual threads, the streaming api, sealed interfaces, and
+  record classes. The structured concurrency experiment is enabled and free to
+  use as well. use context7 to get the documentation for JDK 25.
+  - Use records for data carriers and sealed interfaces for closed hierarchies
+  - Always prefer `ImmutableList.of()`, `ImmutableList.builder()`, or
+    `stream().collect(ImmutableList.toImmutableList())`
+  - Address all warnings immediately. Use `@SuppressWarnings` only as a last
+    resort and _always_ with a justifying comment
+- 100% branch coverage is required in testing. Testing is based on JUnit 5,
+  AssertJ, and Cucumber.
+- This is a Gradle project using the Kotlin DSL. Do not use groovy.
+- This is a high complexity project that demands adherence to rigid coding
+  standards and makes heavy use of abstractions.
+  - Run `./gradlew spotlessApply` before every commit or check
+  - Read the error messages carefully. They usually point to specific style
+    violations or potential bugs
+- This is a system that values correctness, completeness, and flexibility.
+- Vert.x is the base build system. Injection is handled by Guice.
 
 ## Definition of Done
 
-This system uses a robust set of automated tests to ensure compliance with quality standards. In order for a patch to be merged, it must first pass those quality checks.
+This system uses a robust set of automated tests to ensure compliance with
+quality standards. In order for a patch to be merged, it must first pass those
+quality checks.
 
 1. Logic is complete
 2. Tests are written, including integration tests in cucumber if appropriate
-3. `./gradlew spotlessApply` has been run. If this is not done then spontaneous failurs will hapepn in other parts of the pipeline.
-4. `./gradlew check` has been run and passes. If this is not done then the code cannot be merged and will not be reviewed to be merged.
-5. `./gradlew build` has been run and passes. If this is not done then the code cannot be merged and will not be reviewed to be merged.
+3. `./gradlew spotlessApply` has been run. If this is not done then spontaneous
+   failurs will hapepn in other parts of the pipeline.
+4. `./gradlew check` has been run and passes. If this is not done then the code
+   cannot be merged and will not be reviewed to be merged.
+5. `./gradlew build` has been run and passes. If this is not done then the code
+   cannot be merged and will not be reviewed to be merged.
 
-Once these criteria are met then the code may be pushed. You do not need to confirm readiness to push if these criteria are met.
+Once these criteria are met then the code may be pushed. You do not need to
+confirm readiness to push if these criteria are met.
 
 ## Core Documents
 
-* `AGENTS.md`: You are here. A guide for agent development, also lays out broader coding standards.
-* `.agents/SKILLS.md`: A routing file for determining which skills are needed and which files to load as a result. The skills themselves are stored in `.agents/skills/` files.
-* [CONTRIBUTING.md](./CONTRIBUTING.md): Guide for getting started on and contributing to this project. Intended for humans.
-* [README.md](./README.md): Guide for using this project, getting it trunning, and understanding the basic layout and features. Intended for humans though useful for agents.
+- `AGENTS.md`: You are here. A guide for agent development, also lays out
+  broader coding standards.
+- `.agents/SKILLS.md`: A routing file for determining which skills are needed
+  and which files to load as a result. The skills themselves are stored in
+  `.agents/skills/` files.
+- [CONTRIBUTING.md](./CONTRIBUTING.md): Guide for getting started on and
+  contributing to this project. Intended for humans.
+- [README.md](./README.md): Guide for using this project, getting it trunning,
+  and understanding the basic layout and features. Intended for humans though
+  useful for agents.
 
 ## Technical Configuration
 
- * Multi-Module Architecture: To ensure separation of concerns, the project is organized into distinct modules:
-   * `:parent` Contains the central dependencies. All modules within the system inherit `:parent`.  Java library.
-   * `:test` Contains the common test dependencies and some additional utilities for other modules to import.
-   * `:common` Basic utilities and objects that are not central to the core logic of the system.
-   * `:proto` The wire protocol objects. Serialized with protobuf. Library.
-   * `:api` The basic API for the REST service. Library.
-   * `:init` Initialization code for the vert.x system and guice bindings. Library.
-   * `:server` The server and main entry point. Application.
-   * `:integration` Contains archunit tests and also cucumber integration tests.
-   * `:bom` Applies the java-platform plugin and pulls in all of the other modules and dependencies. 
+- Multi-Module Architecture: To ensure separation of concerns, the project is
+  organized into distinct modules:
+  - `:parent` Contains the central dependencies. All modules within the system
+    inherit `:parent`. Java library.
+  - `:test` Contains the common test dependencies and some additional utilities
+    for other modules to import.
+  - `:common` Basic utilities and objects that are not central to the core logic
+    of the system.
+  - `:proto` The wire protocol objects. Serialized with protobuf. Library.
+  - `:api` The basic API for the REST service. Library.
+  - `:init` Initialization code for the vert.x system and guice bindings.
+    Library.
+  - `:server` The server and main entry point. Application.
+  - `:integration` Contains archunit tests and also cucumber integration tests.
+  - `:bom` Applies the java-platform plugin and pulls in all of the other
+    modules and dependencies.
 
 ## Workflow
 
-Act as a senior Java developer. Before outputting the code, mentally verify it against the Checkstyle and Spotbugs configurations. If a line exceeds 100 characters or lacks a proper Javadoc, rewrite it before sending the final response.
+Act as a senior Java developer. Before outputting the code, mentally verify it
+against the Checkstyle and Spotbugs configurations. If a line exceeds 100
+characters or lacks a proper Javadoc, rewrite it before sending the final
+response.
 
-* Before writing the implementation for a feature, write a comprehensive test suite in `:integration` that covers edge cases, null handling, and happy paths. Ensure the tests follow our Checkstyle rules for naming conventions. Only after the tests are written, provide the implementation code that satisfies them.
-* Before writing a class that has any non-storage functionality, write a comprehensive junit test suite that covers edge cases, null handling, and happy paths. Ensure the tests follow our Checkstyle rules for naming conventions. Only after the tests are written, provide the implementation code that satisfies them.
-* Version Control Standards:
-  * Feature branches must be prefixed with `<agent name>/`, so `jules/` for jules.
-  * A linear commit history is required; developers must rebase on the main branch rather than performing merge commits.
-* Do not seek validation of if there is "any more work left to do" unless work has already been specified for you. Always favor getting the code compliant with checks.
-* There is a github action that will run on every commit. It _must_ pass in order for the PR to be merged.
-* If a commit looks like it will be greater than 500 lines, try to split it into multiple independent commits within the same PR. Some pieces of work that should generally almost always be split off into independent commits:
-  * Adding a new module
-  * Any changes to code quality checks that goes in alongside other work
-  * Significant refactoring of old code
-  * Cleanly separable "units of work" that take place in different modules (so doing the cli work separate from the configuration work). 
-* Execution Order:  
+- Before writing the implementation for a feature, write a comprehensive test
+  suite in `:integration` that covers edge cases, null handling, and happy
+  paths. Ensure the tests follow our Checkstyle rules for naming conventions.
+  Only after the tests are written, provide the implementation code that
+  satisfies them.
+- Before writing a class that has any non-storage functionality, write a
+  comprehensive junit test suite that covers edge cases, null handling, and
+  happy paths. Ensure the tests follow our Checkstyle rules for naming
+  conventions. Only after the tests are written, provide the implementation code
+  that satisfies them.
+- Version Control Standards:
+  - Feature branches must be prefixed with `<agent name>/`, so `jules/` for
+    jules.
+  - A linear commit history is required; developers must rebase on the main
+    branch rather than performing merge commits.
+- Do not seek validation of if there is "any more work left to do" unless work
+  has already been specified for you. Always favor getting the code compliant
+  with checks.
+- There is a github action that will run on every commit. It _must_ pass in
+  order for the PR to be merged.
+- If a commit looks like it will be greater than 500 lines, try to split it into
+  multiple independent commits within the same PR. Some pieces of work that
+  should generally almost always be split off into independent commits:
+  - Adding a new module
+  - Any changes to code quality checks that goes in alongside other work
+  - Significant refactoring of old code
+  - Cleanly separable "units of work" that take place in different modules (so
+    doing the cli work separate from the configuration work).
+- Execution Order:
   - Step 1: List the edge cases you will test.
   - Step 2: Write the Test class.
   - Step 3: Write the Implementation class.
 
 ## Code Quality and Static Analysis
 
- * Formatting Standards: The Spotless plugin, configured with Google Java Format, shall be used to enforce a uniform coding style.
- * Static Analysis: Developers must utilize Checkstyle, SpotBugs, and ErrorProne to identify and rectify potential defects and stylistic inconsistencies during the build process.
- * Warning Mitigation: Compilation warnings must be resolved. The use of `@SuppressWarnings` is permitted only when accompanied by thorough documentation justifying the exception.
- * API Documentation: Publicly accessible types and methods require comprehensive Javadoc documentation. Brief descriptions may be omitted only if the functionality is inherently self-evident from the identifier naming.
-
-
-
-
+- Formatting Standards: The Spotless plugin, configured with Google Java Format,
+  shall be used to enforce a uniform coding style.
+- Static Analysis: Developers must utilize Checkstyle, SpotBugs, and ErrorProne
+  to identify and rectify potential defects and stylistic inconsistencies during
+  the build process.
+- Warning Mitigation: Compilation warnings must be resolved. The use of
+  `@SuppressWarnings` is permitted only when accompanied by thorough
+  documentation justifying the exception.
+- API Documentation: Publicly accessible types and methods require comprehensive
+  Javadoc documentation. Brief descriptions may be omitted only if the
+  functionality is inherently self-evident from the identifier naming.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,58 +1,83 @@
 # Use of Generative AI in Contributions
 
-> [!IMPORTANT]
-> This policy has **ZERO TOLERANCE** around anything labeled **MUST**. Especially for wilful violation. 
+> [!IMPORTANT] This policy has **ZERO TOLERANCE** around anything labeled
+> **MUST**. Especially for wilful violation.
 
-Summary position: 
+Summary position:
 
 > We use AI to help us build the world, but AI will not run the world.
 
-Generative AI agents are allowed in this project, but with some guiding principles. 
+Generative AI agents are allowed in this project, but with some guiding
+principles.
 
-1. **Mandatory Disclosure**: AI Contributions **MUST** be disclosed. The agent _MAY_ sign on as a co-contributor or you _MAY_ indicate
-   such in the body of the commit, but either way it **MUST** be disclosed. The contribution **SHOULD** include information on _that_
-   the contribution includes AI, the _extent_ of AI contribution in the PR (e.g., tests, scaffolding, all of it), **and** _which_ AI agent or
-   agents were used (e.g., jules/gemini 3, claud 4, GPT-5).
-2. **Forbidden Tools**: The following AI tools are forbidden for _any_ use in contributions. You **MUST** not use them in any way on this project. This list may change over time:
-   * Grok/xAI
-   * Llama/Meta AI
-   * Devin/Cognition AI
-   * Perplexity AI
-   * Stability AI (and in general we won't use any AI generated "art")
-3. **Principal Authorship**: A human (_you_) **MUST** be listed as the primary author.
-4. **Accountability**: A human (_you_) are responsible for any contributions put under your name, regardless of if they use an AI. You
-   **MUST** ensure that the terms and conditions of the generative AI tool do not place any contractual restrictions
-   on how the tool’s output can be used that are inconsistent with the project’s open source software license or policies.
-   * **Anti-Plagiarism**: If an AI generates a known algorithm (e.g., a specific R-tree implementation), the contributor is responsible for verifying it does
-     not infringe on restrictive patents or licenses incompatible with this project. The contributor is also responsible for ensuring that
-     the algorithm's origin is accurately cited.
-   * **Proper Usage** If others contributions are included in the output from an AI tool, you **MUST** ensure that it is compatible with the license structure
-     of both the code's origin AND this project's policies.
-5. **Human Validation**: You **MUST** personally review and validate any code contributed by an AI agent in your name. This **MUST** be done _BEFORE_
+1. **Mandatory Disclosure**: AI Contributions **MUST** be disclosed. The agent
+   _MAY_ sign on as a co-contributor or you _MAY_ indicate such in the body of
+   the commit, but either way it **MUST** be disclosed. The contribution
+   **SHOULD** include information on _that_ the contribution includes AI, the
+   _extent_ of AI contribution in the PR (e.g., tests, scaffolding, all of it),
+   **and** _which_ AI agent or agents were used (e.g., jules/gemini 3, claud 4,
+   GPT-5).
+2. **Forbidden Tools**: The following AI tools are forbidden for _any_ use in
+   contributions. You **MUST** not use them in any way on this project. This
+   list may change over time:
+   - Grok/xAI
+   - Llama/Meta AI
+   - Devin/Cognition AI
+   - Perplexity AI
+   - Stability AI (and in general we won't use any AI generated "art")
+3. **Principal Authorship**: A human (_you_) **MUST** be listed as the primary
+   author.
+4. **Accountability**: A human (_you_) are responsible for any contributions put
+   under your name, regardless of if they use an AI. You **MUST** ensure that
+   the terms and conditions of the generative AI tool do not place any
+   contractual restrictions on how the tool’s output can be used that are
+   inconsistent with the project’s open source software license or policies.
+   - **Anti-Plagiarism**: If an AI generates a known algorithm (e.g., a specific
+     R-tree implementation), the contributor is responsible for verifying it
+     does not infringe on restrictive patents or licenses incompatible with this
+     project. The contributor is also responsible for ensuring that the
+     algorithm's origin is accurately cited.
+   - **Proper Usage** If others contributions are included in the output from an
+     AI tool, you **MUST** ensure that it is compatible with the license
+     structure of both the code's origin AND this project's policies.
+5. **Human Validation**: You **MUST** personally review and validate any code
+   contributed by an AI agent in your name. This **MUST** be done _BEFORE_
    submitting it for others to review.
-6. **Quality Standards**: AI Agents output is held to extremely strict quality standards and the build must pass successfully (humans are also held to this standard,
-   but many of the elements have seemed easier for humans than AI agents). They **SHOULD** follow the guidance in `AGENTS.md` and `.agents/SKILLS.md`.
+6. **Quality Standards**: AI Agents output is held to extremely strict quality
+   standards and the build must pass successfully (humans are also held to this
+   standard, but many of the elements have seemed easier for humans than AI
+   agents). They **SHOULD** follow the guidance in `AGENTS.md` and
+   `.agents/SKILLS.md`.
 7. **Isolation of Concerns**:
-   * Agent contributions **SHOULD NOT** modify the code quality system unless _directly_ requested to do so. 
-   * Agent contributions **SHOULD NOT** mix code quality changes with functional changes.
-8. **Branch Naming and Grouping**: Agent contributions **SHOULD** as a best effort name their branches as `<agent name>/<branch name>`, e.g., `jules/my-feature-change`.
-   This is an easy one to miss, but check for it the best you can.
-9. **Security and Privacy**: You **MUST NOT** include credentials, non-anonymized production data, or proprietary logic in prompts to AI agents for
-   for contributions to this project.
+   - Agent contributions **SHOULD NOT** modify the code quality system unless
+     _directly_ requested to do so.
+   - Agent contributions **SHOULD NOT** mix code quality changes with functional
+     changes.
+8. **Branch Naming and Grouping**: Agent contributions **SHOULD** as a best
+   effort name their branches as `<agent name>/<branch name>`, e.g.,
+   `jules/my-feature-change`. This is an easy one to miss, but check for it the
+   best you can.
+9. **Security and Privacy**: You **MUST NOT** include credentials,
+   non-anonymized production data, or proprietary logic in prompts to AI agents
+   for for contributions to this project.
 
 ## A Note on Using AI in Pipeline Versus Process
 
-Generative AI tooling may **never** be integrated into the actual pipeline for this tool. This tool is about building and coordinating community
-spaces and games, _not_ about using AI agents for tasks.
+Generative AI tooling may **never** be integrated into the actual pipeline for
+this tool. This tool is about building and coordinating community spaces and
+games, _not_ about using AI agents for tasks.
 
-AI tools may be used to contribute source code, they may never be part of the core loop of this system.
+AI tools may be used to contribute source code, they may never be part of the
+core loop of this system.
 
 ## Inspirations and Further Reading
 
-* [ACM Code of Ethics and Professional Conduct](https://www.acm.org/code-of-ethics)
-* [Linux Foundation Generative AI Principles](https://www.linuxfoundation.org/legal/generative-ai)
-* [IEEE Ethically Aligned Design](https://standards.ieee.org/wp-content/uploads/import/documents/other/ead_v2.pdf)
+- [ACM Code of Ethics and Professional Conduct](https://www.acm.org/code-of-ethics)
+- [Linux Foundation Generative AI Principles](https://www.linuxfoundation.org/legal/generative-ai)
+- [IEEE Ethically Aligned Design](https://standards.ieee.org/wp-content/uploads/import/documents/other/ead_v2.pdf)
 
-----
+---
 
-Use of Generative AI in Contributions © 2026 by Devorah H. Clements is licensed under Creative Commons Attribution-ShareAlike 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
+Use of Generative AI in Contributions © 2026 by Devorah H. Clements is licensed
+under Creative Commons Attribution-ShareAlike 4.0 International. To view a copy
+of this license, visit https://creativecommons.org/licenses/by-sa/4.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,16 @@
 # Contributing to LarpConnect
 
-First off, thank you for considering contributing to LarpConnect! 
+First off, thank you for considering contributing to LarpConnect!
 
-LarpConnect is partly an experiment to see what the limits of AI are for programming complex tasks while maintaining strict code
-quality standards and rules. But it is, at its core, first and foremost, an online distributed application that is designed to run on the internet.
-So we welcome contributions _so long as they adhere to the guidelines and checks put into place_.
+LarpConnect is partly an experiment to see what the limits of AI are for
+programming complex tasks while maintaining strict code quality standards and
+rules. But it is, at its core, first and foremost, an online distributed
+application that is designed to run on the internet. So we welcome contributions
+_so long as they adhere to the guidelines and checks put into place_.
 
-> [!IMPORTANT]]
-> AI Policy: Purely AI-generated contributions without human oversight are not permitted.
-> Contributors must review and take full responsibility for their code. See [AI_POLICY.md](./AI_POLICY.md) for details
+> [!IMPORTANT]] AI Policy: Purely AI-generated contributions without human
+> oversight are not permitted. Contributors must review and take full
+> responsibility for their code. See [AI_POLICY.md](./AI_POLICY.md) for details
 
 ## Table of Contents
 
@@ -23,41 +25,55 @@ So we welcome contributions _so long as they adhere to the guidelines and checks
 
 ## Ground Rules
 
-LarpConnect is a high-complexity project that values correctness, testing, and adherence to rigid coding standards.
+LarpConnect is a high-complexity project that values correctness, testing, and
+adherence to rigid coding standards.
 
-- **Quality first:** All contributions must pass the full suite of automated checks, including tests, static analysis (Checkstyle, SpotBugs, ErrorProne), and formatting (Spotless).
-- **Communication:** For major changes or enhancements, please create an issue first to discuss your proposal.
-- **Respect the architecture:** Adhere to the multi-module structure and dependency management rules.
-- **Linear History:** We maintain a linear commit history. Rebasing on the main branch is required.
-- **You Are Not an AI:** You aren't expected to write like an AI or engage with the `@AiContract` blocks at all. We have tools that will follow
-  along and hopefully clean these up accurately. 
+- **Quality first:** All contributions must pass the full suite of automated
+  checks, including tests, static analysis (Checkstyle, SpotBugs, ErrorProne),
+  and formatting (Spotless).
+- **Communication:** For major changes or enhancements, please create an issue
+  first to discuss your proposal.
+- **Respect the architecture:** Adhere to the multi-module structure and
+  dependency management rules.
+- **Linear History:** We maintain a linear commit history. Rebasing on the main
+  branch is required.
+- **You Are Not an AI:** You aren't expected to write like an AI or engage with
+  the `@AiContract` blocks at all. We have tools that will follow along and
+  hopefully clean these up accurately.
 
 ## Your First Contribution
 
 Unsure where to begin? Look for issues labeled "beginner" or "help wanted".
 
 If you're new to open source, here are some helpful resources:
+
 - [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
 - [First Timers Only](http://www.firsttimersonly.com/)
 
 ## Getting Started
 
 1.  **Fork the repository** and create your branch from `main`.
-2.  **Branch naming:** Feature branches created by AIs must prefixed with `<ai name>/`, e.g., `jules/`. This does not apply to humans.
+2.  **Branch naming:** Feature branches created by AIs must prefixed with
+    `<ai name>/`, e.g., `jules/`. This does not apply to humans.
 3.  **Set up your environment:** Ensure you have Java 25 installed.
 4.  **Make your changes.**
 5.  **Format your code:** Run `./gradlew spotlessApply` before committing.
-6.  **Verify your changes:** Run `./gradlew check` to execute tests and static analysis.
+6.  **Verify your changes:** Run `./gradlew check` to execute tests and static
+    analysis.
 7.  **At least once before submitting:** Run `./gradlew build`.
 8.  **Submit a Pull Request.**
 
 ## How to Report a Bug
 
 ### Security Disclosures
-If you find a security vulnerability, do NOT open an issue. Please contact the maintainers directly.
+
+If you find a security vulnerability, do NOT open an issue. Please contact the
+maintainers directly.
 
 ### Filing a Bug Report
+
 When filing an issue, please include:
+
 - A clear, descriptive title.
 - Steps to reproduce the issue.
 - Expected behavior vs. actual behavior.
@@ -74,17 +90,22 @@ If you have a feature idea:
 ## Code Review Process
 
 - All pull requests will be reviewed by the core team.
-- Feedback will be provided on code quality, architectural alignment, and adherence to standards.
+- Feedback will be provided on code quality, architectural alignment, and
+  adherence to standards.
 - You may be asked to rebase your branch or update your tests.
 
 ## Coding Standards and Technical Requirements
 
-Detailed technical standards are maintained in [AGENTS.md](AGENTS.md). Key highlights include:
+Detailed technical standards are maintained in [AGENTS.md](AGENTS.md). Key
+highlights include:
 
-- **Java 25:** Use modern features like Records, Sealed Classes, and Pattern Matching.
-- **Null Safety:** Use `Optional<T>` for potentially absent values. No direct `.get()`.
+- **Java 25:** Use modern features like Records, Sealed Classes, and Pattern
+  Matching.
+- **Null Safety:** Use `Optional<T>` for potentially absent values. No direct
+  `.get()`.
 - **Dependency Injection:** Use Guice with constructor injection.
-- **Testing:** JUnit 5, AssertJ, and Mockito. Follow the naming pattern: `<method>_<what is being tested>_<expected outcome>`.
+- **Testing:** JUnit 5, AssertJ, and Mockito. Follow the naming pattern:
+  `<method>_<what is being tested>_<expected outcome>`.
 - **Immutability:** Prefer immutable collections and final variables.
 - **Logging:** Use SLF4J.
 
@@ -96,4 +117,5 @@ Detailed technical standards are maintained in [AGENTS.md](AGENTS.md). Key highl
 
 ---
 
-For more details, please refer to the [README.md](README.md) and [AGENTS.md](AGENTS.md).
+For more details, please refer to the [README.md](README.md) and
+[AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # LARPConnect: Connecting LARP Communities
 
-> [!CAUTION]
-> **DEVELOPMENT STATUS: PRE-ALPHA**
-> This project is **not** ready for production traffic. **DO NOT USE IT IN PRODUCTION.** Core security, stability, and data integrity features are still under active development.
-
+> [!CAUTION] > **DEVELOPMENT STATUS: PRE-ALPHA** This project is **not** ready
+> for production traffic. **DO NOT USE IT IN PRODUCTION.** Core security,
+> stability, and data integrity features are still under active development.
 
 [![Build](https://github.com/larpconnect/larpconnect/actions/workflows/build.yml/badge.svg)](https://github.com/larpconnect/larpconnect/actions/workflows/build.yml)
 
@@ -11,34 +10,43 @@
 
 ## Project Overview
 
-**LARPConnect** is a platform designed to bridge and federate Live Action Role-Playing (LARP) communities. It allows for the creation of interconnected subcommunities that can communicate and share resources.
+**LARPConnect** is a platform designed to bridge and federate Live Action
+Role-Playing (LARP) communities. It allows for the creation of interconnected
+subcommunities that can communicate and share resources.
 
-Think of it as a Discord-like or Mastodon-like experience tailored specifically for the needs of LARPers, with a heavy focus on:
+Think of it as a Discord-like or Mastodon-like experience tailored specifically
+for the needs of LARPers, with a heavy focus on:
 
-* **Community Federation:** Connecting disparate groups while allowing for local subcommunity autonomy.
-* **Data and Metadata Management:** Tracking complex game data, character information, and announcements from staff in a usable, searchable format.
-* **Logistics & Signups:** Integrated tools for event registration and resource tracking.
+- **Community Federation:** Connecting disparate groups while allowing for local
+  subcommunity autonomy.
+- **Data and Metadata Management:** Tracking complex game data, character
+  information, and announcements from staff in a usable, searchable format.
+- **Logistics & Signups:** Integrated tools for event registration and resource
+  tracking.
 
 ---
 
 ## Technical Specifications
 
-The project is a multi-module Gradle build designed for high performance and type safety.
+The project is a multi-module Gradle build designed for high performance and
+type safety.
 
-* **Language:** Java 25
-* **Framework:** Vert.x 5
-* **Build System:** Gradle (Multi-module)
-* **Main Entry Point:** `:server` 
+- **Language:** Java 25
+- **Framework:** Vert.x 5
+- **Build System:** Gradle (Multi-module)
+- **Main Entry Point:** `:server`
 
 ---
 
 ## Getting Started
 
 ### Prerequisites
-* **JDK 25** or higher.
-* **Gradle 9.3+** (via the included wrapper).
+
+- **JDK 25** or higher.
+- **Gradle 9.3+** (via the included wrapper).
 
 ### Build Instructions
+
 To compile the project and run the test suite:
 
 ```bash
@@ -46,7 +54,10 @@ To compile the project and run the test suite:
 ```
 
 ### Updating OpenAPI Specs
-To regenerate the OpenAPI specification (`openapi.yaml`) from Protobuf definitions and copy it to `src/main/resources` where it should be checked into version control, run:
+
+To regenerate the OpenAPI specification (`openapi.yaml`) from Protobuf
+definitions and copy it to `src/main/resources` where it should be checked into
+version control, run:
 
 ```bash
 ./gradlew :proto:updateOpenApi
@@ -62,8 +73,9 @@ To run the server directly via Gradle:
 
 ### Configuration
 
-LarpConnect's configuration can be modified through `config.json`. For detailed information on
-configuration settings, namespacing, and specifying custom configuration files, please refer to the
+LarpConnect's configuration can be modified through `config.json`. For detailed
+information on configuration settings, namespacing, and specifying custom
+configuration files, please refer to the
 [Configuration Guide](docs/configuration.md).
 
 ### Creating a Fatjar
@@ -104,11 +116,15 @@ curl -v http://localhost:8080/v1/message
 
 All source code and comments licensed under Apache 2.0
 
-See [LICENSE](./LICENSE) for more details. 
+See [LICENSE](./LICENSE) for more details.
 
 Not affiliated with or endorsed by Google LLC in any way.
 
 Exceptions are as follows:
 
-* Use of Generative AI in Contributions is licensed under Creative Commons Attribution-ShareAlike 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
-* The contents of the `docs/` folder is licensed under Creative Commons Attribution 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/.
+- Use of Generative AI in Contributions is licensed under Creative Commons
+  Attribution-ShareAlike 4.0 International. To view a copy of this license,
+  visit https://creativecommons.org/licenses/by-sa/4.0/
+- The contents of the `docs/` folder is licensed under Creative Commons
+  Attribution 4.0 International. To view a copy of this license, visit
+  https://creativecommons.org/licenses/by/4.0/.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("com.diffplug.spotless")
+}
+
+spotless {
+    format("markdown") {
+        target("**/*.md")
+        targetExclude("**/build/**")
+        prettier().config(mapOf("parser" to "markdown", "proseWrap" to "always"))
+    }
+}
+
+tasks.withType<com.diffplug.gradle.spotless.SpotlessTask>().configureEach {
+    if (name.contains("Markdown") && name.contains("Check")) {
+        enabled = false
+    }
+}
+
+tasks.named("spotlessCheck") {
+    dependsOn(tasks.matching { it.name.contains("Markdown") && it.name.contains("Check") }.map { it.apply { enabled = false } })
+}

--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -1,2 +1,3 @@
-This folder (and only this folder) os licensed under Creative Commons Attribution 4.0 International.
-To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/
+This folder (and only this folder) os licensed under Creative Commons
+Attribution 4.0 International. To view a copy of this license, visit
+https://creativecommons.org/licenses/by/4.0/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,26 +1,30 @@
 # Configuration Guide
 
-LarpConnect uses a JSON configuration file to manage application settings. The main configuration
-file is typically named `config.json` and must be provided to the application upon startup.
+LarpConnect uses a JSON configuration file to manage application settings. The
+main configuration file is typically named `config.json` and must be provided to
+the application upon startup.
 
 This document explains how to configure LarpConnect and the available settings.
 
 ## The `larpconnect` Namespace
 
-All configuration settings specific to LarpConnect are contained within a top-level JSON object
-named `larpconnect`. This ensures that LarpConnect settings do not conflict with other
-configuration values that might be present in the environment or provided by other tools.
+All configuration settings specific to LarpConnect are contained within a
+top-level JSON object named `larpconnect`. This ensures that LarpConnect
+settings do not conflict with other configuration values that might be present
+in the environment or provided by other tools.
 
-The application reads the full JSON configuration object when it starts. The main server module
-then extracts the settings from the `larpconnect` namespace. If a setting is not found within the
-namespace, the application will attempt to fall back to the root level of the configuration file,
-though placing settings in the namespace is strongly recommended.
+The application reads the full JSON configuration object when it starts. The
+main server module then extracts the settings from the `larpconnect` namespace.
+If a setting is not found within the namespace, the application will attempt to
+fall back to the root level of the configuration file, though placing settings
+in the namespace is strongly recommended.
 
 ### Specifying the Configuration File
 
-By default, LarpConnect attempts to load the configuration from a file named `config.json` on the
-classpath. You can override this default behavior and specify a custom configuration file location
-by setting the `njall.config.resource` system property when starting the application.
+By default, LarpConnect attempts to load the configuration from a file named
+`config.json` on the classpath. You can override this default behavior and
+specify a custom configuration file location by setting the
+`njall.config.resource` system property when starting the application.
 
 For example, to load a configuration file named `custom-config.json`:
 
@@ -36,24 +40,25 @@ Currently, LarpConnect supports the following configuration properties:
 
 ### `web.port`
 
-* **Type:** Integer
-* **Default Value:** 8080
-* **Description:** This property specifies the network port that the LarpConnect web server will
-  bind to and listen on for incoming HTTP requests. You can change this if port 8080 is already in
-  use by another application on your system.
+- **Type:** Integer
+- **Default Value:** 8080
+- **Description:** This property specifies the network port that the LarpConnect
+  web server will bind to and listen on for incoming HTTP requests. You can
+  change this if port 8080 is already in use by another application on your
+  system.
 
 ### `openapi.spec`
 
-* **Type:** String
-* **Default Value:** `openapi.yaml`
-* **Description:** This property defines the path or name of the OpenAPI specification file that
-  the server uses to configure its API routes and validation. The file must be accessible on the
-  application's classpath.
+- **Type:** String
+- **Default Value:** `openapi.yaml`
+- **Description:** This property defines the path or name of the OpenAPI
+  specification file that the server uses to configure its API routes and
+  validation. The file must be accessible on the application's classpath.
 
 ## Configuration Example
 
-Here is an example of a valid `config.json` file that sets the web server to run on port 9000
-and uses a custom OpenAPI specification file:
+Here is an example of a valid `config.json` file that sets the web server to run
+on port 9000 and uses a custom OpenAPI specification file:
 
 ```json
 {
@@ -64,13 +69,14 @@ and uses a custom OpenAPI specification file:
 }
 ```
 
-If you do not provide a `config.json` file, or if the file is missing these properties, the
-application will start using the default values (port 8080 and `openapi.yaml`).
+If you do not provide a `config.json` file, or if the file is missing these
+properties, the application will start using the default values (port 8080 and
+`openapi.yaml`).
 
 ## How Configuration is Loaded
 
-When LarpConnect starts, the entry point initializes the Vert.x framework and Guice dependency
-injection. The configuration file is read and passed into the Guice `ServerModule`. This module
-is responsible for providing the configuration values to the various parts of the application,
-such as the `WebServerVerticle`, which uses the `web.port` and `openapi.spec` settings to start
-the HTTP server.
+When LarpConnect starts, the entry point initializes the Vert.x framework and
+Guice dependency injection. The configuration file is read and passed into the
+Guice `ServerModule`. This module is responsible for providing the configuration
+values to the various parts of the application, such as the `WebServerVerticle`,
+which uses the `web.port` and `openapi.spec` settings to start the HTTP server.


### PR DESCRIPTION
Enable spotless for markdown files globally and ignore formatting checks

- Add root `build.gradle.kts` configuration with Spotless
- Add `spotless` configuration block for markdown files using Prettier and Github Flavored Markdown (GFM) defaults (`parser: markdown`, `proseWrap: always`)
- Exclude `build` directory from targets
- Exclude Spotless Markdown checking from the `check` task by setting the task to not enabled (`enabled = false`)

---
*PR created automatically by Jules for task [3069725519002434763](https://jules.google.com/task/3069725519002434763) started by @dclements*