### PR TITLE
fix(spotless): preserve markdown blockquote formatting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ spotless {
     format("markdown") {
         target("**/*.md")
         targetExclude("**/build/**")
-        prettier().config(mapOf("parser" to "markdown", "proseWrap" to "always"))
+        prettier().config(mapOf("parser" to "markdown", "proseWrap" to "preserve"))
     }
 }
 


### PR DESCRIPTION
This PR updates the Prettier configuration for Spotless markdown formatting to use `proseWrap: preserve` instead of `always`. This ensures that line wrapping in blockquotes, especially GitHub Flavored Markdown alerts like `> [!IMPORTANT]`, are not incorrectly reflowed by Prettier, which breaks the GFM rendering.

- Updated `proseWrap` from `"always"` to `"preserve"` in `build.gradle.kts`.

---
*PR created automatically by Jules for task [7980407949969299114](https://jules.google.com/task/7980407949969299114) started by @dclements*