### PR TITLE
feat: read PORT environment variable for web server port config

### DIFF
--- a/server/src/test/java/com/larpconnect/njall/server/ServerModuleTest.java
+++ b/server/src/test/java/com/larpconnect/njall/server/ServerModuleTest.java
@@ -3,9 +3,42 @@ package com.larpconnect.njall.server;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.vertx.core.json.JsonObject;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 final class ServerModuleTest {
+  @Test
+  void provideWebPort_usesPortEnvVar_whenPresentAndValid() {
+    Function<String, String> envProvider = name -> "PORT".equals(name) ? "9999" : null;
+    var module = new ServerModule(envProvider);
+    var config = new JsonObject().put("larpconnect", new JsonObject().put("web.port", 1234));
+
+    var port = module.provideWebPort(config);
+
+    assertThat(port).isEqualTo(9999);
+  }
+
+  @Test
+  void provideWebPort_fallsBackToConfig_whenPortEnvVarInvalid() {
+    Function<String, String> envProvider = name -> "PORT".equals(name) ? "invalid" : null;
+    var module = new ServerModule(envProvider);
+    var config = new JsonObject().put("larpconnect", new JsonObject().put("web.port", 1234));
+
+    var port = module.provideWebPort(config);
+
+    assertThat(port).isEqualTo(1234);
+  }
+
+  @Test
+  void provideWebPort_fallsBackToConfig_whenPortEnvVarNull() {
+    Function<String, String> envProvider = name -> null;
+    var module = new ServerModule(envProvider);
+    var config = new JsonObject().put("larpconnect", new JsonObject().put("web.port", 1234));
+
+    var port = module.provideWebPort(config);
+
+    assertThat(port).isEqualTo(1234);
+  }
 
   @Test
   void provideWebPort_usesLarpconnectConfig_whenPresent() {


### PR DESCRIPTION
This pull request introduces support for automatically setting the application's exposed port from the `PORT` environment variable if it exists and is a valid integer. If it is unset or invalid, the previous fallback logic is retained. Unit tests were added to verify the environment variable parsing behavior and fallback cases.

---
*PR created automatically by Jules for task [3575584983372061219](https://jules.google.com/task/3575584983372061219) started by @dclements*