### PR TITLE
📄 Nihiluxinator: Document PORT environment variable fallback

### DIFF
--- a/.agents/nihiluxinator/log.md
+++ b/.agents/nihiluxinator/log.md
@@ -1,0 +1,9 @@
+## 2024-05-19 - Discovered `PORT` Environment Variable Configuration
+
+**Learning:** The `web.port` can also be configured using the standard `PORT` environment variable
+(which takes precedence over the `config.json` file configuration) as implemented in
+`ServerBindingModule.java`. This is a common pattern for cloud deployments (like Render or Heroku)
+but is currently undocumented in `docs/configuration.md`.
+
+**Action:** Update the documentation to reflect that the `PORT` environment variable can be used to
+set the `web.port` and takes precedence over `config.json` values.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ To run the server directly via Gradle:
 ### Configuration
 
 LarpConnect's configuration can be modified through `config.json`. For detailed
-information on configuration settings, namespacing, and specifying custom
+information on configuration settings, environment variables (like `PORT`),
+namespacing, and specifying custom
 configuration files, please refer to the
 [Configuration Guide](docs/configuration.md).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,11 @@ Currently, LarpConnect supports the following configuration properties:
   change this if port 8080 is already in use by another application on your
   system.
 
+  > [!NOTE]
+  > The `PORT` environment variable takes precedence over the `web.port` setting
+  > in `config.json`. This is commonly used in cloud deployments. If `PORT` is
+  > not set or not a valid integer, the application falls back to `web.port`.
+
 ### `openapi.spec`
 
 - **Type:** String


### PR DESCRIPTION
💡 What was changed:
- Documented that the `PORT` environment variable takes precedence over the `web.port` configuration in `config.json`.
- Updated `docs/configuration.md` with a NOTE section explaining this.
- Cross-referenced environment variable configuration in `README.md`.
- Added a journal entry for this discovery in `.agents/nihiluxinator/log.md`.

🎯 Why the documentation is helpful:
- Environment variables like `PORT` are extremely common in cloud deployments (e.g. Render, Heroku) and the fallback behavior in `ServerBindingModule.java` was completely undocumented, making it confusing for users trying to deploy the application without writing a custom config.json.

---
*PR created automatically by Jules for task [3007520683048830098](https://jules.google.com/task/3007520683048830098) started by @dclements*