### PR TITLE
Zhongliinator: Add package-info and Guice annotations to common.id package

### DIFF
--- a/.agents/zhongliinator/log.md
+++ b/.agents/zhongliinator/log.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Default implementations need not be specified if the target is package private
+
+**Learning:** For `IdGenerator` which has `@DefaultImplementation(UuidV7Generator.class)` maybe we can apply it. Wait, `UuidV7Generator` is package private. Check if `IdGenerator` has `@DefaultImplementation`? Let's verify.

--- a/common/src/main/java/com/larpconnect/njall/common/id/IdBindingModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdBindingModule.java
@@ -2,9 +2,11 @@ package com.larpconnect.njall.common.id;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.larpconnect.njall.common.annotations.InstallInstead;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.random.RandomGenerator;
 
+@InstallInstead(IdModule.class)
 final class IdBindingModule extends AbstractModule {
   IdBindingModule() {}
 

--- a/common/src/main/java/com/larpconnect/njall/common/id/IdGenerator.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdGenerator.java
@@ -1,8 +1,10 @@
 package com.larpconnect.njall.common.id;
 
 import com.larpconnect.njall.common.annotations.AiContract;
+import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import java.util.UUID;
 
+@DefaultImplementation(UuidV7Generator.class)
 public interface IdGenerator {
   /**
    * Generates a new unique identifier.

--- a/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
@@ -1,5 +1,6 @@
 package com.larpconnect.njall.common.id;
 
+import com.larpconnect.njall.common.annotations.BuildWith;
 import com.larpconnect.njall.common.time.TimeService;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
@@ -9,6 +10,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.random.RandomGenerator;
 
 @Singleton
+@BuildWith(IdModule.class)
 final class UuidV7Generator implements IdGenerator {
 
   private static final long MIN_COUNTER = 3L;

--- a/common/src/main/java/com/larpconnect/njall/common/id/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.larpconnect.njall.common.id;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
💡 What was changed:
- Added `package-info.java` to `com.larpconnect.njall.common.id` with `@ParametersAreNonnullByDefault` and `@ReturnValuesAreNonnullByDefault` annotations.
- Annotated `IdBindingModule` with `@InstallInstead(IdModule.class)`.
- Annotated `IdGenerator` with `@DefaultImplementation(UuidV7Generator.class)`.
- Annotated `UuidV7Generator` with `@BuildWith(IdModule.class)`.

🎯 Why it helps make the build system better:
- Provides better nullability context to the `common.id` package, enabling compile-time and agent-time enforcement of non-null inputs and outputs.
- Connects interfaces and their default implementations with `@DefaultImplementation` and `@BuildWith` to help future developers (and agents) navigate and comprehend the dependency graph.
- Formalizes the module installation delegation through `@InstallInstead` to clearly delineate architectural boundaries.

Skill used: context engineering

---
*PR created automatically by Jules for task [13838743373189705214](https://jules.google.com/task/13838743373189705214) started by @dclements*