### PR TITLE
🪳 Nifftyinator: CLEAN! IT! UP!

### DIFF
--- a/init/src/main/java/com/larpconnect/njall/init/VerticleLifecycle.java
+++ b/init/src/main/java/com/larpconnect/njall/init/VerticleLifecycle.java
@@ -14,6 +14,7 @@ import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -51,8 +52,10 @@ final class VerticleLifecycle extends AbstractIdleService implements VerticleSer
       var configResource = System.getProperty("njall.config.resource", "config.json");
       var url = Resources.getResource(configResource);
       defaultConfig = new JsonObject(Resources.toString(url, StandardCharsets.UTF_8));
-    } catch (IllegalArgumentException | IOException e) {
-      throw new RuntimeException("Failed to load default config", e);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Failed to load default config", e);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to load default config", e);
     }
 
     // Create temp Vertx for config loading
@@ -73,11 +76,11 @@ final class VerticleLifecycle extends AbstractIdleService implements VerticleSer
       config = future.get(CONFIG_LOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Interrupted while loading config", e);
+      throw new IllegalStateException("Interrupted while loading config", e);
     } catch (ExecutionException e) {
-      throw new RuntimeException("Failed to load config", e);
+      throw new IllegalStateException("Failed to load config", e);
     } catch (TimeoutException e) {
-      throw new RuntimeException("Timed out loading config", e);
+      throw new IllegalStateException("Timed out loading config", e);
     } finally {
       tempVertx.close();
     }

--- a/init/src/main/java/com/larpconnect/njall/init/VerticleSetupService.java
+++ b/init/src/main/java/com/larpconnect/njall/init/VerticleSetupService.java
@@ -52,7 +52,7 @@ final class VerticleSetupService {
         .onFailure(
             err -> {
               logger.error("Failed to deploy verticle", err);
-              throw new RuntimeException(
+              throw new IllegalStateException(
                   "Failed to deploy verticle " + verticleClass.getName(), err);
             });
   }


### PR DESCRIPTION
💡 What was changed
Replaced generic `RuntimeException` throws with more specific exceptions in `VerticleSetupService` and `VerticleLifecycle`.

Consistency edits that were needed
Ensured exceptions matched the actual error conditions:
- Wrap `IOException` during config read in `java.io.UncheckedIOException`
- Wrap deployment errors or lifecycle interrupted exceptions with `IllegalStateException`
- Wrap illegal argument when default config isn't correctly supplied with `IllegalArgumentException`

---
*PR created automatically by Jules for task [3608519165305850586](https://jules.google.com/task/3608519165305850586) started by @dclements*