### PR TITLE
Zhongliinator: Added missing package-info.java to common subpackages

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/annotations/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/annotations/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.larpconnect.njall.common.annotations;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/common/src/main/java/com/larpconnect/njall/common/codec/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.larpconnect.njall.common.codec;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/common/src/main/java/com/larpconnect/njall/common/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.larpconnect.njall.common;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/common/src/main/java/com/larpconnect/njall/common/time/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/time/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.larpconnect.njall.common.time;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/common/src/main/java/com/larpconnect/njall/common/verticle/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/verticle/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
+package com.larpconnect.njall.common.verticle;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
💡 What was changed
Added `package-info.java` files to several sub-packages within the `common` module (`common`, `time`, `codec`, `verticle`, and `annotations`) that were missing package-level nullability annotations.

🎯 Why it helps make the build system better
These annotations (`@ParametersAreNonnullByDefault` and `@ReturnValuesAreNonnullByDefault`) improve the context provided to agents by ensuring that local variables, return values, and parameters are assumed non-null by default. This significantly increases code clarity, tightens safety guarantees, and assists both human developers and automatic agents in preventing null-pointer exceptions across these packages.

---
*PR created automatically by Jules for task [7641137949368336263](https://jules.google.com/task/7641137949368336263) started by @dclements*