### PR TITLE
🚧 Pentiousinator: Reduce duplication in dependency declarations

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -3,5 +3,4 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":parent"))
 }

--- a/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
@@ -20,6 +20,9 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 dependencies {
+    if (project.name != "parent") {
+        api(project(":parent"))
+    }
     api(libs.slf4j.api)
     constraints {
         implementation(libs.commons.beanutils) {

--- a/buildSrc/src/main/kotlin/larpconnect.testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.testing.gradle.kts
@@ -10,18 +10,6 @@ dependencies {
     if (project.name != "test") {
         testImplementation(project(":test"))
     }
-    testImplementation(libs.junit.api)
-    testImplementation(libs.junit.params)
-    testImplementation(libs.assertj.core)
-    testImplementation(libs.assertj.guava)
-    testImplementation(libs.mockito.core)
-    testImplementation(libs.mockito.junit.jupiter)
-    testImplementation(libs.cucumber.java)
-    testImplementation(libs.cucumber.junit.platform.engine)
-    testImplementation(libs.junit.platform.suite)
-
-    testRuntimeOnly(libs.junit.engine)
-    testRuntimeOnly(libs.junit.platform.launcher)
     testRuntimeOnly(libs.logback.classic)
 }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,17 +3,9 @@ plugins {
 }
 
 dependencies {
-    api(project(":parent"))
     api(project(":proto"))
-    api(libs.vertx.core)
-    api(libs.slf4j.api)
-    api(libs.guava)
 
-    testImplementation(project(":test"))
     testImplementation(libs.vertx.junit5)
-    testImplementation(libs.junit.api)
-    testRuntimeOnly(libs.junit.engine)
-    testImplementation(libs.assertj.core)
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/init/build.gradle.kts
+++ b/init/build.gradle.kts
@@ -3,13 +3,9 @@ plugins {
 }
 
 dependencies {
-    api(project(":parent"))
     implementation(project(":proto"))
     implementation(project(":common"))
-    implementation(libs.vertx.core)
     implementation(libs.vertx.config)
-    implementation(libs.guice)
-    implementation(libs.guava)
     implementation(libs.protobuf.java)
 
     compileOnly(libs.vertx.codegen)

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -5,12 +5,9 @@ plugins {
 dependencies {
     testImplementation(project(":api"))
     testImplementation(project(":common"))
-    testImplementation(project(":parent"))
     testImplementation(project(":proto"))
     testImplementation(project(":server"))
-    testImplementation(project(":test"))
     testImplementation(project(":init"))
-    testImplementation(libs.vertx.core)
     testImplementation(libs.vertx.web.client)
     testImplementation(libs.vertx.junit5)
     testCompileOnly(libs.vertx.codegen)

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":parent"))
     api(libs.protobuf.java)
     implementation(libs.google.common.protos)
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -3,18 +3,15 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":parent"))
     implementation(project(":common"))
     implementation(project(":init"))
     implementation(project(":proto"))
-    implementation(libs.vertx.core)
     implementation(libs.vertx.config)
     implementation(libs.vertx.healthcheck)
     implementation(libs.vertx.web)
     implementation(libs.vertx.openapi)
     implementation(libs.vertx.web.openapi.router)
     implementation(libs.protobuf.java.util)
-    implementation(libs.guice)
     compileOnly(libs.vertx.codegen)
     testCompileOnly(libs.vertx.codegen)
     testImplementation(libs.vertx.junit5)

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -3,13 +3,15 @@ plugins {
 }
 
 dependencies {
-    api(project(":parent"))
     api(libs.junit.api)
     api(libs.junit.params)
+    api(libs.junit.platform.suite)
     api(libs.assertj.core)
     api(libs.assertj.guava)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
     api(libs.cucumber.java)
     api(libs.cucumber.junit.platform.engine)
+    runtimeOnly(libs.junit.engine)
+    runtimeOnly(libs.junit.platform.launcher)
 }


### PR DESCRIPTION
💡 What was changed
This pull request streamlines dependency declarations by allowing the `larpconnect.java-common` and `larpconnect.testing` convention plugins in `buildSrc` to centrally propagate the core `:parent` module and test dependencies to all applied subprojects. Subsequently, duplicate declarations were cleaned up across all module `build.gradle.kts` files.

🎯 Why it helps make the build system better
It reduces boilerplate and repetition across the build system, establishing a single source of truth for library versioning and application scope. It enforces the intended inheritance hierarchy of `:parent` and `:test` modules uniformly across the Gradle architecture, mitigating the risk of divergent classpaths or forgotten test dependency imports in the future.

---
*PR created automatically by Jules for task [1324552198631671168](https://jules.google.com/task/1324552198631671168) started by @dclements*