### PR TITLE
📄 Nihiluxinator: Add architectural 'why' Javadocs to core services

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,7 +38,6 @@ The protocol variation here is an implementation of some ideas I had earlier for
 and we'll see how those play out in practice. This design is not supposed to be backwards compatible with AP as it
 is used today, but more looking forward to what else can be done in this space.
 
-
 ## Features
 
 (TBD)
@@ -80,7 +79,7 @@ Changes MUST be thoroughly tested. API features SHOULD have integration tests wr
 have some combination of unit and integration tests.
 
 The project, to this end, enforces extremely aggressive testing requirements: 80% instruction, 90% branch coverage. This
-means that, as you write code, you need to have tests go in on the same commit. 
+means that, as you write code, you need to have tests go in on the same commit.
 
 ### Code Quality
 
@@ -88,8 +87,8 @@ Code quality is enforced via several mechanisms.
 
 #### Spotless + Google Java Standards
 
-This ensures that all of the code that is submitted follows a (relatively) consistent set of standards. This is not 
-sufficient, but it cleans up a lot of little things like whitespace and imports. 
+This ensures that all of the code that is submitted follows a (relatively) consistent set of standards. This is not
+sufficient, but it cleans up a lot of little things like whitespace and imports.
 
 #### Checkstyle
 
@@ -98,12 +97,12 @@ doing that I don't want for the sake of consistency.
 
 #### SpotBugs
 
-Catches a lot of standard bug patterns. 
+Catches a lot of standard bug patterns.
 
 #### ArchUnit
 
 This enforces some of the heavier weight requirements that, again, AIs have trouble following. Often things around
-visibility or the "out or down" dependency requirements. 
+visibility or the "out or down" dependency requirements.
 
 ### Context Engineering
 
@@ -125,10 +124,10 @@ To do this we use a few different annotations:
   _bindings_ to be in modules (hence why we don't use `@ImplementedBy`), but this acts as a hint to agents as to where to go.
 
 That said: _contributors_ are not expected to worry about these. We have agents and humans to help keep them up to date, and the most that
-we expect you to do is delete the annotation if you change the situation that lead to it in the first place. 
+we expect you to do is delete the annotation if you change the situation that lead to it in the first place.
 
 #### Skills
 
 We define multiple skills in `.agents/skills/` in the form of markdown files. These are to provide specialized context to agents and let
-them "opt in" to the degree of specialization that they need. 
+them "opt in" to the degree of specialization that they need.
 

--- a/common/src/main/java/com/larpconnect/njall/common/id/IdGenerator.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdGenerator.java
@@ -4,12 +4,25 @@ import com.larpconnect.njall.common.annotations.AiContract;
 import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import java.util.UUID;
 
+/**
+ * An abstraction for generating unique identifiers across the system.
+ *
+ * <p>Centralizing ID generation provides two main architectural benefits. First, it allows the
+ * system to standardise on a specific ID format (such as UUIDv7) that may have desirable properties
+ * like lexicographical sorting, without coupling consumers to a specific library or implementation.
+ * Second, it abstracts away randomness and temporal dependencies, enabling test doubles to inject
+ * predictable or deterministic IDs during unit and integration testing.
+ */
 @DefaultImplementation(UuidV7Generator.class)
 public interface IdGenerator {
   /**
-   * Generates a new unique identifier.
+   * Generates a new, system-wide unique identifier.
    *
-   * @return a new UUID
+   * <p>This method abstracts the underlying complexity of ID creation (e.g., mixing timestamp,
+   * machine ID, and entropy) to provide a simple, uniform interface for assigning identities to new
+   * entities or events.
+   *
+   * @return a new uniquely generated UUID
    */
   @AiContract(ensure = "$res \\neq \\bot", implementationHint = "Generates a unique identifier.")
   UUID generate();

--- a/common/src/main/java/com/larpconnect/njall/common/time/TimeService.java
+++ b/common/src/main/java/com/larpconnect/njall/common/time/TimeService.java
@@ -3,11 +3,24 @@ package com.larpconnect.njall.common.time;
 import com.google.common.util.concurrent.Service;
 import com.larpconnect.njall.common.annotations.AiContract;
 
+/**
+ * A central service providing a uniform view of temporal operations within the application.
+ *
+ * <p>Directly referencing {@code System.currentTimeMillis()} or {@code System.nanoTime()} scatters
+ * implicit, uncontrollable dependencies throughout the codebase. By injecting a uniform {@link
+ * TimeService}, the application gains full control over the clock. This makes it possible to mock
+ * time for unit tests, safely perform time-travel or freeze time scenarios, and guarantee
+ * reproducibility in time-sensitive workflows.
+ */
 public interface TimeService extends Service {
   /**
-   * Gets the monotonic time in milliseconds.
+   * Retrieves a reliable, monotonically increasing timestamp.
    *
-   * @return the monotonic time in milliseconds
+   * <p>This method abstracts the operating system's monotonic clock. Monotonic clocks are immune to
+   * backwards leaps, leap-seconds, or manual resets of the system clock. It should be strictly used
+   * for tracking durations or elapsed time, rather than representing an exact wall-clock moment.
+   *
+   * @return a non-decreasing timestamp in milliseconds
    */
   @AiContract(
       ensure = "$res \\ge 0",


### PR DESCRIPTION
💡 What was changed:
Added detailed, class-level Javadocs to `IdGenerator.java` and `TimeService.java` that focus on the architectural "why" rather than just the "what".

🎯 Why the documentation is helpful:
By explaining the purpose of these central services (e.g., standardizing UUID formats, abstracting time to enable time-travel/freezing in unit tests), other developers and AI agents can better understand their utility and importance within the LarpConnect architecture. This directly aligns with Nihiluxinator's goal of ensuring documentation explains the *why* of the system.


---
*PR created automatically by Jules for task [14219326499649587887](https://jules.google.com/task/14219326499649587887) started by @dclements*