### PR TITLE
Add Authentication and Header to Message

### DIFF
--- a/proto/src/main/proto/message.proto
+++ b/proto/src/main/proto/message.proto
@@ -28,8 +28,24 @@ message MimeType {
   bytes content = 3;
 }
 
+enum AuthStatus {
+  SUCCEEDED = 0;
+  FAILED = 1;
+}
+
+message Authentication {
+  string username = 1;
+  AuthStatus status = 2;
+}
+
+message Header {
+  repeated string accept = 1;
+}
+
 message Message {
   Observability traceparent = 1;
+  Authentication authentication = 4;
+  Header header = 5;
 
   oneof payload {
     ProtoDef proto = 2;

--- a/proto/src/main/resources/openapi.yaml
+++ b/proto/src/main/resources/openapi.yaml
@@ -26,6 +26,14 @@ paths:
                                 $ref: '#/components/schemas/Status'
 components:
     schemas:
+        Authentication:
+            type: object
+            properties:
+                username:
+                    type: string
+                status:
+                    type: integer
+                    format: enum
         GoogleProtobufAny:
             type: object
             properties:
@@ -34,11 +42,22 @@ components:
                     description: The type of the serialized message.
             additionalProperties: true
             description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+        Header:
+            type: object
+            properties:
+                accept:
+                    type: array
+                    items:
+                        type: string
         Message:
             type: object
             properties:
                 traceparent:
                     $ref: '#/components/schemas/Observability'
+                authentication:
+                    $ref: '#/components/schemas/Authentication'
+                header:
+                    $ref: '#/components/schemas/Header'
                 proto:
                     $ref: '#/components/schemas/ProtoDef'
                 mime:


### PR DESCRIPTION
This PR expands the `Message` object to include new `Authentication` and `Header` types.

- `AuthStatus` enum with `SUCCEEDED` and `FAILED`.
- `Authentication` message containing `username` and `status`.
- `Header` message containing a repeated `accept` string for MIME types.
- Updated `Message` to include `authentication` and `header` fields.
- Regenerated the OpenAPI specification (`openapi.yaml`) to reflect these changes.

---
*PR created automatically by Jules for task [3981909092369591678](https://jules.google.com/task/3981909092369591678) started by @dclements*