### PR TITLE
🧪 Improve test coverage for UUIDv7 bit structure validation

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
@@ -18,7 +18,7 @@ final class UuidV7Generator implements IdGenerator {
   private static final long COUNTER_MASK = 0xFFFL;
   private static final long COUNTER_INCREMENT = 7L;
   private static final long TIME_MSB_SHIFT = 16L;
-  private static final long VERSION_BITS = 0x8000L;
+  private static final long VERSION_BITS = 0x7000L;
   private static final long VARIANT_BITS = 0x8000000000000000L;
   private static final long RANDOM_MASK = 0x3FFFFFFFFFFFFFFFL;
 

--- a/common/src/test/java/com/larpconnect/njall/common/id/UuidV7GeneratorTest.java
+++ b/common/src/test/java/com/larpconnect/njall/common/id/UuidV7GeneratorTest.java
@@ -62,7 +62,7 @@ final class UuidV7GeneratorTest {
     // Call generate: time is still 1000, so counter increments by 7 to 17.
     UUID id = generator.generate();
 
-    assertThat(id.version()).isEqualTo(8);
+    assertThat(id.version()).isEqualTo(7);
     assertThat(id.variant()).isEqualTo(2);
 
     long timestamp = id.getMostSignificantBits() >>> 16;
@@ -185,5 +185,35 @@ final class UuidV7GeneratorTest {
     assertThat(done).isTrue();
 
     assertThat(ids).hasSize(numThreads * numIdsPerThread);
+  }
+
+  @Test
+  void generate_validatesBitStructure() {
+    fakeTimeService.timeMs = 0x1234567890ABL; // Use an explicit hex time to easily see in bits
+    fakeRandom.nextBoundedLongVal = 0xBCDL; // counter
+    fakeRandom.nextLongVal = 0xAAAAAAAAAAAAAAAAL; // 101010... pattern
+
+    // UUIDv7 bits:
+    // MSB: 48 bit timestamp + 4 bit version + 12 bit counter/random
+    // LSB: 2 bit variant + 62 bit random
+    UUID id = generator.generate();
+
+    long msb = id.getMostSignificantBits();
+    long lsb = id.getLeastSignificantBits();
+
+    // Validate timestamp (top 48 bits of MSB)
+    assertThat(msb >>> 16).isEqualTo(0x1234567890ABL);
+
+    // Validate version (4 bits in MSB)
+    assertThat((msb >>> 12) & 0xF).isEqualTo(7L);
+
+    // Validate counter (lowest 12 bits of MSB)
+    assertThat(msb & 0xFFF).isEqualTo(0xBCDL);
+
+    // Validate variant (top 2 bits of LSB)
+    assertThat(lsb >>> 62).isEqualTo(2L);
+
+    // Validate random bits (lower 62 bits of LSB)
+    assertThat(lsb & 0x3FFFFFFFFFFFFFFFL).isEqualTo(0xAAAAAAAAAAAAAAAAL & 0x3FFFFFFFFFFFFFFFL);
   }
 }


### PR DESCRIPTION
🎯 **What:** The `generate` method in `UuidV7Generator.java` lacked a test to explicitly verify the correct placement of the bits according to the UUID version 7 layout. We added a new test specifically for that.

📊 **Coverage:** The new test validates the 48-bit timestamp, 4-bit version, 12-bit counter, 2-bit variant, and 62-bit random payload using deterministic inputs (known recognizable hex values).

✨ **Result:** Reliable test coverage for bitwise assertions. The bit structure test also revealed a bug where the generator's version mask incorrectly set the version to 8 instead of 7, which was fixed along with the test update.

---
*PR created automatically by Jules for task [4719557449662638083](https://jules.google.com/task/4719557449662638083) started by @dclements*