### PR TITLE
🧪 [Add error path test for MonotonicTimeService start]

### DIFF
--- a/common/src/test/java/com/larpconnect/njall/common/time/MonotonicTimeServiceTest.java
+++ b/common/src/test/java/com/larpconnect/njall/common/time/MonotonicTimeServiceTest.java
@@ -10,6 +10,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.Test;
 
 final class MonotonicTimeServiceTest {
@@ -63,6 +64,37 @@ final class MonotonicTimeServiceTest {
     ticker.advanceNanos(5_000_000L); // 5 ms
 
     assertThat(service.monotonicNowMillis()).isEqualTo(1005L);
+  }
+
+  @Test
+  void monotonicNowMillis_starting_throwsException() throws Exception {
+    var clock = new FakeClock(Instant.ofEpochMilli(1000));
+    var ticker = new FakeTicker();
+    var latch = new CountDownLatch(1);
+    var startedLatch = new CountDownLatch(1);
+
+    MonotonicTimeService service =
+        new MonotonicTimeService(
+            clock,
+            () -> {
+              startedLatch.countDown();
+              try {
+                latch.await();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return Stopwatch.createUnstarted(ticker);
+            });
+
+    service.startAsync();
+    startedLatch.await(); // ensure we have entered startUp and are blocking
+
+    assertThatThrownBy(service::monotonicNowMillis)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("MonotonicTimeService is not started");
+
+    latch.countDown();
+    service.awaitRunning();
   }
 
   @Test


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of an error path test covering the initialization window of `MonotonicTimeService.monotonicNowMillis()`. Specifically, calling this method when the service is starting up (i.e., state is `STARTING`) and the stopwatch hasn't been instantiated yet.
📊 **Coverage:** The new test ensures that an `IllegalStateException` is correctly thrown during this startup window, effectively proving that the `if (stopwatch == null)` branch handles calls made immediately after `startAsync()` is called but before `awaitRunning()` is complete.
✨ **Result:** Increased test coverage for the error condition handling of monotonic time access, preventing subtle race condition bugs where callers might query the service before it has fully initialized.

---
*PR created automatically by Jules for task [1621875153804574574](https://jules.google.com/task/1621875153804574574) started by @dclements*