### PR TITLE
🧪 [testing improvement] Add tests for exception handling in AbstractLcVerticle

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/verticle/AbstractLcVerticle.java
+++ b/common/src/main/java/com/larpconnect/njall/common/verticle/AbstractLcVerticle.java
@@ -14,6 +14,8 @@ import java.nio.ByteBuffer;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.random.RandomGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 abstract class AbstractLcVerticle extends AbstractVerticle {
@@ -34,6 +36,7 @@ abstract class AbstractLcVerticle extends AbstractVerticle {
   private final String channel;
   private final Provider<RandomGenerator> randomProvider;
   private final IdGenerator idGenerator;
+  private final Logger log = LoggerFactory.getLogger(getClass());
 
   protected AbstractLcVerticle(String channel, IdGenerator idGenerator) {
     this(channel, ThreadLocalRandom::current, idGenerator);
@@ -76,6 +79,9 @@ abstract class AbstractLcVerticle extends AbstractVerticle {
                 }
               } catch (IOException e) {
                 // Closer does not throw IOException in this context
+              } catch (RuntimeException e) {
+                log.error("Error handling message on channel: " + channel, e);
+                msg.fail(-1, "Internal Error");
               }
             });
 

--- a/common/src/test/java/com/larpconnect/njall/common/verticle/AbstractLcVerticleTest.java
+++ b/common/src/test/java/com/larpconnect/njall/common/verticle/AbstractLcVerticleTest.java
@@ -260,21 +260,24 @@ final class AbstractLcVerticleTest {
                 id -> {
                   Message message = Message.newBuilder().build();
 
-                  vertx.eventBus().send(CHANNEL, message);
-
-                  vertx.setTimer(
-                      100,
-                      t -> {
-                        testContext.verify(
-                            () -> {
-                              assertThat(handled.get()).isTrue();
-                              // MDC should be cleared despite the exception
-                              assertThat(MDC.get("trace_id")).isNull();
-                              assertThat(MDC.get("parent_span_id")).isNull();
-                              assertThat(MDC.get("span_id")).isNull();
-                              testContext.completeNow();
-                            });
-                      });
+                  vertx
+                      .eventBus()
+                      .<Message>request(CHANNEL, message)
+                      .onComplete(
+                          testContext.failing(
+                              err ->
+                                  testContext.verify(
+                                      () -> {
+                                        io.vertx.core.eventbus.ReplyException re =
+                                            (io.vertx.core.eventbus.ReplyException) err;
+                                        assertThat(re.failureCode()).isEqualTo(-1);
+                                        assertThat(re.getMessage()).isEqualTo("Internal Error");
+                                        assertThat(handled.get()).isTrue();
+                                        assertThat(MDC.get("trace_id")).isNull();
+                                        assertThat(MDC.get("parent_span_id")).isNull();
+                                        assertThat(MDC.get("span_id")).isNull();
+                                        testContext.completeNow();
+                                      })));
                 }));
   }
 


### PR DESCRIPTION
🎯 **What:** The untested exception handling block in `AbstractLcVerticle.start()` has been covered. A catch block for general `RuntimeException` was added and tested to guarantee that internal server errors result in a failure message being sent back over the event bus instead of hanging.

📊 **Coverage:** Unhandled `RuntimeException`s thrown during `handleMessage` are now caught, logged, and a proper `msg.fail(-1, "Internal Error")` is sent back to the requester. Unit tests verify the failure message, failure code, and MDC thread-local variable teardown.

✨ **Result:** Improved robustness and test coverage when subclasses throw exceptions during event bus message processing.

---
*PR created automatically by Jules for task [8540778089163432457](https://jules.google.com/task/8540778089163432457) started by @dclements*