### PR TITLE
📄 Nihiluxinator: Add architectural Javadocs to core interfaces

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/verticle/BasicResponse.java
+++ b/common/src/main/java/com/larpconnect/njall/common/verticle/BasicResponse.java
@@ -1,6 +1,17 @@
 package com.larpconnect.njall.common.verticle;
 
+/**
+ * Standard responses that indicate what the underlying verticle should do next after processing a
+ * message.
+ *
+ * <p>By abstracting the control flow (such as shutting down the consumer or acknowledging the
+ * message) away from the business logic handling the message, this allows verticles to remain
+ * focused on handling events without needing to directly manipulate the Vert.x EventBus.
+ */
 public enum BasicResponse implements MessageResponse {
+  /** Indicates that the verticle should continue processing messages on this channel. */
   CONTINUE,
+
+  /** Indicates that the verticle should unregister its consumer from the EventBus. */
   SHUTDOWN
 }

--- a/init/src/main/java/com/larpconnect/njall/init/VerticleService.java
+++ b/init/src/main/java/com/larpconnect/njall/init/VerticleService.java
@@ -4,7 +4,21 @@ import com.google.common.util.concurrent.Service;
 import com.larpconnect.njall.common.annotations.AiContract;
 import io.vertx.core.Verticle;
 
+/**
+ * A central service interface for managing the initialization and deployment of Verticles.
+ *
+ * <p>The system relies heavily on Guice to satisfy dependencies. By extending {@link Service}, this
+ * interface provides a clean lifecycle (via Guava's ServiceManager) to handle the complex
+ * bootstrapping required to marry Vert.x's asynchronous deployment model with a synchronous,
+ * injected setup process.
+ */
 public interface VerticleService extends Service {
+
+  /**
+   * Submits a Verticle class for deployment.
+   *
+   * @param verticleClass the class of the Verticle to deploy
+   */
   @AiContract(
       require = "verticleClass \\neq \\bot",
       ensure = "verticleClass \\text{ is deployed}",

--- a/init/src/main/java/com/larpconnect/njall/init/VerticleServices.java
+++ b/init/src/main/java/com/larpconnect/njall/init/VerticleServices.java
@@ -6,7 +6,21 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Module;
 import com.larpconnect.njall.common.annotations.AiContract;
 
+/**
+ * A static factory for instantiating the {@link VerticleService} implementation.
+ *
+ * <p>Abstracting the creation into this factory interface prevents calling code (like the main
+ * entry point) from needing direct access to the concrete {@code VerticleLifecycle} class,
+ * preserving encapsulation within the {@code init} module.
+ */
 public interface VerticleServices {
+
+  /**
+   * Instantiates a new {@code VerticleService} that manages the provided Guice modules.
+   *
+   * @param modules an immutable list of Guice modules used to configure the application's bindings
+   * @return a new, unstarted VerticleService instance
+   */
   @AiContract(
       require = "modules \\neq \\bot",
       ensure = {"$res \\neq \\bot", "$res \\text{ is a new VerticleLifecycle}"},

--- a/server/src/main/java/com/larpconnect/njall/server/MainVerticle.java
+++ b/server/src/main/java/com/larpconnect/njall/server/MainVerticle.java
@@ -3,5 +3,14 @@ package com.larpconnect.njall.server;
 import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import io.vertx.core.Verticle;
 
+/**
+ * A marker interface indicating the root verticle from which all other application verticles are
+ * launched.
+ *
+ * <p>By depending on an interface instead of a concrete class, the initialization code (like {@code
+ * com.larpconnect.njall.init.VerticleLifecycle}) can blindly deploy the bound {@code MainVerticle}
+ * class without coupling the generic initialization logic to the specific modules or verticles
+ * needed by the application server.
+ */
 @DefaultImplementation(DefaultMainVerticle.class)
 public interface MainVerticle extends Verticle {}


### PR DESCRIPTION
💡 **What was changed**
Added architectural "why-focused" Javadocs to several core interfaces and enums across the `:common`, `:init`, and `:server` modules:
* `BasicResponse`
* `VerticleService`
* `VerticleServices`
* `MainVerticle`

**Consistency edits that were needed.**
Ran spotlessApply to ensure line limits (100) and general formatting guidelines were met. 

🎯 **Why the documentation is helpful**
These edits bring the undocumented interfaces into compliance with the documentation standard of focusing on the "why" and architectural design choices instead of just the "what". For example, explaining why `VerticleService` uses Guava's `Service` to bridge the gap between Vert.x async deployments and synchronous Guice injections.

---
*PR created automatically by Jules for task [8097395612465477761](https://jules.google.com/task/8097395612465477761) started by @dclements*