### PR TITLE
🪳 Nifftyinator: CLEAN! IT! UP!

### DIFF
--- a/init/src/test/java/com/larpconnect/njall/init/VerticleSetupServiceTest.java
+++ b/init/src/test/java/com/larpconnect/njall/init/VerticleSetupServiceTest.java
@@ -53,14 +53,14 @@ final class VerticleSetupServiceTest {
   }
 
   @Test
-  void deploy_failure_throwsRuntimeException() {
-    var failure = new RuntimeException("fail");
+  void deploy_failure_throwsIllegalStateException() {
+    var failure = new IllegalStateException("fail");
     when(mockVertx.deployVerticle(anyString())).thenReturn(Future.failedFuture(failure));
 
     service.setup(mockVertx, mockInjector);
 
     assertThatThrownBy(() -> service.deploy(TestVerticle.class))
-        .isInstanceOf(RuntimeException.class)
+        .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Failed to deploy verticle")
         .hasCause(failure);
   }

--- a/server/src/test/java/com/larpconnect/njall/server/DefaultMainVerticleTest.java
+++ b/server/src/test/java/com/larpconnect/njall/server/DefaultMainVerticleTest.java
@@ -39,7 +39,7 @@ final class DefaultMainVerticleTest {
   static final class FailingVerticle extends AbstractVerticle {
     @Override
     public void start(Promise<Void> startPromise) {
-      startPromise.fail(new RuntimeException("Fail"));
+      startPromise.fail(new IllegalStateException("Fail"));
     }
   }
 
@@ -77,7 +77,7 @@ final class DefaultMainVerticleTest {
     Vertx mockVertx = mock(Vertx.class);
     Context mockContext = mock(Context.class);
 
-    RuntimeException failure = new RuntimeException("Deployment failed");
+    IllegalStateException failure = new IllegalStateException("Deployment failed");
     when(mockVertx.deployVerticle(any(Verticle.class))).thenReturn(Future.failedFuture(failure));
 
     mainVerticle.init(mockVertx, mockContext);

--- a/server/src/test/java/com/larpconnect/njall/server/MainTest.java
+++ b/server/src/test/java/com/larpconnect/njall/server/MainTest.java
@@ -52,7 +52,6 @@ final class MainTest {
                 });
     var main = new Main(runtime, overrideModule);
 
-    // Test TimeoutException
     var timeoutService = new TestVerticleService();
     timeoutService.exceptionToThrow.set(new TimeoutException());
     main.shutdown(timeoutService);
@@ -63,9 +62,8 @@ final class MainTest {
      * ensure no propagation of exception.
      */
 
-    // Test RuntimeException
     var runtimeService = new TestVerticleService();
-    runtimeService.exceptionToThrow.set(new RuntimeException());
+    runtimeService.exceptionToThrow.set(new IllegalStateException());
     main.shutdown(runtimeService);
   }
 
@@ -75,14 +73,10 @@ final class MainTest {
     final AtomicBoolean stopCalled = new AtomicBoolean(false);
 
     @Override
-    public void deploy(Class<? extends Verticle> verticleClass) {
-      // No-op
-    }
+    public void deploy(Class<? extends Verticle> verticleClass) {}
 
     @Override
-    protected void startUp() throws Exception {
-      // No-op
-    }
+    protected void startUp() throws Exception {}
 
     @Override
     protected void shutDown() throws Exception {


### PR DESCRIPTION
💡 What was changed
Replaced generic `RuntimeException` instantiations in test code with `IllegalStateException` instances to conform to the Nifftyinator rule #21 regarding specific exception types. Removed pure "cruft" comments in `MainTest.java` (Rule #15).

Consistency edits that were needed
Updated `isInstanceOf` assertions in tests to correctly check for `IllegalStateException` when catching exceptions matching the newly modified mock setups. Reverted earlier mistaken modifications to catch blocks to preserve valid framework exception catch-alls.

---
*PR created automatically by Jules for task [6249717360986002489](https://jules.google.com/task/6249717360986002489) started by @dclements*