### PR TITLE
🧹 Rinainator: Extract ApiBindingModule to adhere to Guice module standards

### DIFF
--- a/.agents/rinainator/log.md
+++ b/.agents/rinainator/log.md
@@ -3,3 +3,9 @@
 **Learning:** The project's Java coding standards specifically avoid using `@Named` for Guice dependency injection, preferring custom qualifier annotations. This makes tracking dependencies across the codebase easier.
 
 **Action:** Replace instances of `@Named` with custom qualifier annotations, specifically in `WebServerVerticle` and `ServerBindingModule`.
+
+## 2026-03-06 - Extracted Guice bindings to a BindingModule to respect architecture rules
+
+**Learning:** According to `.agents/skills/guice_di.md`, each package should have a standard pattern of having a public `Module` that installs a package-private `BindingModule`, rather than putting bindings directly into the public `Module`. `ApiModule` in the `com.larpconnect.njall.api` package did not follow this pattern.
+
+**Action:** Created `ApiBindingModule` and moved `ApiObjectParser`, `JsonFormat.Printer`, and `JsonFormat.Parser` bindings there. Modified `ApiModule` to install `ApiBindingModule` using `@InstallInstead(ApiModule.class)`. This matches the Guice DI standards.

--- a/api/src/main/java/com/larpconnect/njall/api/ApiBindingModule.java
+++ b/api/src/main/java/com/larpconnect/njall/api/ApiBindingModule.java
@@ -1,0 +1,19 @@
+package com.larpconnect.njall.api;
+
+import com.google.inject.AbstractModule;
+import com.google.protobuf.util.JsonFormat;
+import com.larpconnect.njall.common.annotations.InstallInstead;
+
+@InstallInstead(ApiModule.class)
+final class ApiBindingModule extends AbstractModule {
+  ApiBindingModule() {}
+
+  @Override
+  protected void configure() {
+    bind(ApiObjectParser.class).to(DefaultApiObjectParser.class);
+    bind(JsonFormat.Printer.class)
+        .toInstance(
+            JsonFormat.printer().preservingProtoFieldNames().omittingInsignificantWhitespace());
+    bind(JsonFormat.Parser.class).toInstance(JsonFormat.parser().ignoringUnknownFields());
+  }
+}

--- a/api/src/main/java/com/larpconnect/njall/api/ApiModule.java
+++ b/api/src/main/java/com/larpconnect/njall/api/ApiModule.java
@@ -1,7 +1,6 @@
 package com.larpconnect.njall.api;
 
 import com.google.inject.AbstractModule;
-import com.google.protobuf.util.JsonFormat;
 
 /**
  * Guice module for the API module. Exposing it allows other modules to install it and bypasses the
@@ -12,10 +11,6 @@ public final class ApiModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(ApiObjectParser.class).to(DefaultApiObjectParser.class);
-    bind(JsonFormat.Printer.class)
-        .toInstance(
-            JsonFormat.printer().preservingProtoFieldNames().omittingInsignificantWhitespace());
-    bind(JsonFormat.Parser.class).toInstance(JsonFormat.parser().ignoringUnknownFields());
+    install(new ApiBindingModule());
   }
 }

--- a/init/src/main/java/com/larpconnect/njall/init/VerticleLifecycle.java
+++ b/init/src/main/java/com/larpconnect/njall/init/VerticleLifecycle.java
@@ -3,6 +3,7 @@ package com.larpconnect.njall.init;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.ConfigurationException;
 import com.google.inject.Guice;
 import com.google.inject.Module;
 import com.larpconnect.njall.common.annotations.AiContract;
@@ -104,7 +105,7 @@ final class VerticleLifecycle extends AbstractIdleService implements VerticleSer
     try {
       var timeService = injector.getInstance(TimeService.class);
       timeService.startAsync().awaitRunning();
-    } catch (com.google.inject.ConfigurationException e) {
+    } catch (ConfigurationException e) {
       logger.debug("TimeService not bound, skipping start.");
     }
 


### PR DESCRIPTION
💡 What was changed
* Extracted the Guice bindings from `ApiModule` into a new package-private `ApiBindingModule`.
* `ApiModule` was updated to simply `install(new ApiBindingModule())`.
* Added the `@InstallInstead(ApiModule.class)` annotation to `ApiBindingModule`.
* Cleaned up `VerticleLifecycle.java` by adding an import for `ConfigurationException` rather than referencing it inline as `com.google.inject.ConfigurationException`.

Consistency edits that were needed
* This change brings the `com.larpconnect.njall.api` package into compliance with the project's standard DI pattern, ensuring that the public module installs the binding module, rather than registering the bindings directly.

🎯 Why the documentation is helpful
* Logged a critical learning to `.agents/rinainator/log.md` detailing the required Guice Module/BindingModule pattern, making it easier for future modifications to respect this architectural rule.

---
*PR created automatically by Jules for task [15326537029459174422](https://jules.google.com/task/15326537029459174422) started by @dclements*