### PR TITLE
🪳 Nifftyinator: CLEAN! IT! UP!

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
@@ -41,8 +41,10 @@ final class UuidV7Generator implements IdGenerator {
   public UUID generate() {
     long currentTimeMs = timeService.monotonicNowMillis();
 
-    // Generate unconditionally outside the atomic update to avoid side effects during retries
-    // under contention, keeping the update function pure.
+    /*
+     * Generate unconditionally outside the atomic update to avoid side effects during retries
+     * under contention, keeping the update function pure.
+     */
     long nextRandomCounter = randomProvider.get().nextLong(MIN_COUNTER, MAX_COUNTER);
 
     State updatedState =

--- a/init/src/main/java/com/larpconnect/njall/init/VerticleLifecycle.java
+++ b/init/src/main/java/com/larpconnect/njall/init/VerticleLifecycle.java
@@ -77,10 +77,8 @@ final class VerticleLifecycle extends AbstractIdleService implements VerticleSer
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IllegalStateException("Interrupted while loading config", e);
-    } catch (ExecutionException e) {
+    } catch (ExecutionException | TimeoutException e) {
       throw new IllegalStateException("Failed to load config", e);
-    } catch (TimeoutException e) {
-      throw new IllegalStateException("Timed out loading config", e);
     } finally {
       tempVertx.close();
     }


### PR DESCRIPTION
🪳 Nifftyinator: CLEAN! IT! UP!

💡 What was changed
* Converted a multiline `//` comment to a block comment (`/* */`) in `UuidV7Generator.java`.
* Combined `ExecutionException` and `TimeoutException` catch blocks into a single block in `VerticleLifecycle.java`.

Consistency edits that were needed
* Applied standard exception combination rules and comment style cleanup according to Nifftyinator's strict guidelines.

---
*PR created automatically by Jules for task [6341418187986025181](https://jules.google.com/task/6341418187986025181) started by @dclements*