### PR TITLE
🚧 Pentiousinator: Centralize Vert.x codegen dependencies

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,5 +8,4 @@ dependencies {
     implementation(libs.vertx.core)
     implementation(libs.protobuf.java.util)
     implementation(libs.guice)
-    compileOnly(libs.vertx.codegen)
 }

--- a/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.java-common.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
         api(project(":parent"))
     }
     api(libs.slf4j.api)
+    compileOnly(libs.vertx.codegen)
+    testCompileOnly(libs.vertx.codegen)
     constraints {
         implementation(libs.commons.beanutils) {
             because("CVE-2025-48734")

--- a/init/build.gradle.kts
+++ b/init/build.gradle.kts
@@ -3,14 +3,10 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.vertx.codegen)
-
     implementation(project(":common"))
     implementation(project(":proto"))
     implementation(libs.protobuf.java)
     implementation(libs.vertx.config)
-
-    testCompileOnly(libs.vertx.codegen)
 
     testImplementation(libs.vertx.junit5)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-    testCompileOnly(libs.vertx.codegen)
-
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":init"))

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.vertx.codegen)
-
     implementation(project(":common"))
     implementation(project(":init"))
     implementation(project(":proto"))
@@ -14,8 +12,6 @@ dependencies {
     implementation(libs.vertx.openapi)
     implementation(libs.vertx.web)
     implementation(libs.vertx.web.openapi.router)
-
-    testCompileOnly(libs.vertx.codegen)
 
     testImplementation(libs.vertx.junit5)
     testImplementation(libs.vertx.web.client)


### PR DESCRIPTION
💡 What was changed:
Centralized `libs.vertx.codegen` in the `larpconnect.java-common` convention plugin instead of declaring it individually in multiple subprojects (`api`, `server`, `init`, and `integration`).

🎯 Why it helps make the build system better:
This significantly reduces redundancy across the project's build files, making the build system cleaner and easier to maintain. Since many modules rely on Vert.x code generation annotations, this is an excellent candidate for centralizing logic into `buildSrc`.

---
*PR created automatically by Jules for task [14848391309049420867](https://jules.google.com/task/14848391309049420867) started by @dclements*