### PR TITLE
📄 Nihiluxinator: Document UuidV7Generator design decisions

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
@@ -9,6 +9,18 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.random.RandomGenerator;
 
+/**
+ * Implementation of {@link IdGenerator} that produces UUID version 7 identifiers.
+ *
+ * <p>UUIDv7 is used instead of standard UUIDv4 to provide time-ordered uniqueness. This design
+ * decision significantly improves database insert performance and B-tree index locality, as new IDs
+ * are appended sequentially rather than scattered randomly across the index.
+ *
+ * <p>Additionally, because the timestamp is embedded within the ID, it allows for implicit
+ * chronological sorting and reduces the need for separate creation timestamp columns in certain
+ * data models, while still retaining sufficient randomness to avoid collisions in distributed
+ * systems.
+ */
 @Singleton
 @BuildWith(IdModule.class)
 final class UuidV7Generator implements IdGenerator {


### PR DESCRIPTION
💡 What was changed:
Added a class-level Javadoc to `UuidV7Generator.java`.

Consistency edits that were needed:
None - the Javadoc follows the 100-character line length limit and avoids documenting the "what" in favor of the "why".

🎯 Why the documentation is helpful:
It explains the design rationale behind using UUID version 7 identifiers. Specifically, it notes that UUIDv7 provides time-ordered uniqueness, which significantly improves database insert performance and B-tree index locality compared to randomly scattered standard UUIDs. It also clarifies that this approach enables implicit chronological sorting.

---
*PR created automatically by Jules for task [4559625376043066495](https://jules.google.com/task/4559625376043066495) started by @dclements*