### PR TITLE
🪳 Nifftyinator: CLEAN! IT! UP!

### DIFF
--- a/api/src/test/java/com/larpconnect/njall/api/DefaultApiObjectParserTest.java
+++ b/api/src/test/java/com/larpconnect/njall/api/DefaultApiObjectParserTest.java
@@ -14,7 +14,7 @@ import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class DefaultApiObjectParserTest {
+public final class DefaultApiObjectParserTest {
 
   private ApiObjectParser parser;
 


### PR DESCRIPTION
🪳 Nifftyinator: CLEAN! IT! UP!

💡 What was changed
Converted `DefaultApiObjectParserTest` to be a `final` class.

Consistency edits that were needed
This change aligns with Nifftyinator's rule #7 to make classes final when possible. No logic was altered since JUnit 5 fully supports `final` test classes.

---
*PR created automatically by Jules for task [10119316266257270496](https://jules.google.com/task/10119316266257270496) started by @dclements*