### PR TITLE
🚧 Pentiousinator: Centralize vertx-junit5 test dependency in :test module

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
 
 dependencies {
     api(project(":proto"))
-
-    testImplementation(libs.vertx.junit5)
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/init/build.gradle.kts
+++ b/init/build.gradle.kts
@@ -7,6 +7,4 @@ dependencies {
     implementation(project(":proto"))
     implementation(libs.protobuf.java)
     implementation(libs.vertx.config)
-
-    testImplementation(libs.vertx.junit5)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
     testImplementation(project(":proto"))
     testImplementation(project(":server"))
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.vertx.junit5)
-    testImplementation(libs.vertx.web.client)
     testImplementation(libs.protobuf.java.util)
+    testImplementation(libs.vertx.web.client)
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(libs.vertx.web)
     implementation(libs.vertx.web.openapi.router)
 
-    testImplementation(libs.vertx.junit5)
     testImplementation(libs.vertx.web.client)
 }
 

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.vertx.junit5)
 
     runtimeOnly(libs.junit.engine)
     runtimeOnly(libs.junit.platform.launcher)


### PR DESCRIPTION
💡 What was changed
Removed redundant `testImplementation(libs.vertx.junit5)` declarations from `common`, `init`, `integration`, and `server` modules. Added `api(libs.vertx.junit5)` to the central `:test` module.

🎯 Why it helps make the build system better
It reduces duplication and maintains a more consistent dependency hierarchy where common, project-wide testing dependencies are logically captured in the `:test` module. This simplifies module build files and leverages the fact that `larpconnect.testing` already automatically wires `:test` into subprojects.

---
*PR created automatically by Jules for task [11013280165405122592](https://jules.google.com/task/11013280165405122592) started by @dclements*