### PR TITLE
🚧 Pentiousinator: Reduce duplication in dependency declarations

### DIFF
--- a/init/build.gradle.kts
+++ b/init/build.gradle.kts
@@ -4,7 +4,5 @@ plugins {
 
 dependencies {
     implementation(project(":common"))
-    implementation(project(":proto"))
-    implementation(libs.protobuf.java)
     implementation(libs.vertx.config)
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     implementation(project(":common"))
     implementation(project(":init"))
-    implementation(project(":proto"))
     implementation(libs.protobuf.java.util)
     implementation(libs.vertx.config)
     implementation(libs.vertx.healthcheck)


### PR DESCRIPTION
💡 What was changed
Removed redundant `implementation` dependency declarations for `:proto` and `protobuf.java` across multiple modules (`:init`, `:server`).

🎯 Why it helps make the build system better
It reduces clutter in the build scripts and relies on the transitive dependency graphs provided by `:common` and `:init`, preventing potential duplicate resolutions and simplifying the dependency declarations.

---
*PR created automatically by Jules for task [16048463259826563834](https://jules.google.com/task/16048463259826563834) started by @dclements*