### PR TITLE
Refactor IdGenerator into a single implementation service pattern

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/id/IdBindingModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdBindingModule.java
@@ -12,7 +12,8 @@ final class IdBindingModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(IdGenerator.class).to(UuidV7Generator.class);
+    bind(IdGenerator.class).to(IdGeneratorService.class);
+    bind(IdGeneratorService.class).to(UuidV7GeneratorService.class);
   }
 
   @Provides

--- a/common/src/main/java/com/larpconnect/njall/common/id/IdGenerator.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdGenerator.java
@@ -13,7 +13,7 @@ import java.util.UUID;
  * Second, it abstracts away randomness and temporal dependencies, enabling test doubles to inject
  * predictable or deterministic IDs during unit and integration testing.
  */
-@DefaultImplementation(UuidV7Generator.class)
+@DefaultImplementation(IdGeneratorService.class)
 public interface IdGenerator {
   /**
    * Generates a new, system-wide unique identifier.

--- a/common/src/main/java/com/larpconnect/njall/common/id/IdGeneratorService.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdGeneratorService.java
@@ -1,0 +1,8 @@
+package com.larpconnect.njall.common.id;
+
+import com.google.common.util.concurrent.Service;
+import com.larpconnect.njall.common.annotations.DefaultImplementation;
+
+/** A service layer for generating system-wide unique identifiers. */
+@DefaultImplementation(UuidV7GeneratorService.class)
+public interface IdGeneratorService extends IdGenerator, Service {}

--- a/common/src/main/java/com/larpconnect/njall/common/id/UuidV7GeneratorService.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/UuidV7GeneratorService.java
@@ -1,5 +1,6 @@
 package com.larpconnect.njall.common.id;
 
+import com.google.common.util.concurrent.AbstractIdleService;
 import com.larpconnect.njall.common.annotations.BuildWith;
 import com.larpconnect.njall.common.time.TimeService;
 import jakarta.inject.Inject;
@@ -23,7 +24,7 @@ import java.util.random.RandomGenerator;
  */
 @Singleton
 @BuildWith(IdModule.class)
-final class UuidV7Generator implements IdGenerator {
+final class UuidV7GeneratorService extends AbstractIdleService implements IdGeneratorService {
 
   private static final long MIN_COUNTER = 3L;
   private static final long MAX_COUNTER = 1024L;
@@ -41,7 +42,7 @@ final class UuidV7Generator implements IdGenerator {
   private record State(long timeMs, long counter) {}
 
   @Inject
-  UuidV7Generator(TimeService timeService, Provider<RandomGenerator> randomProvider) {
+  UuidV7GeneratorService(TimeService timeService, Provider<RandomGenerator> randomProvider) {
     this.timeService = timeService;
     this.randomProvider = randomProvider;
     long initialCounter = randomProvider.get().nextLong(MIN_COUNTER, MAX_COUNTER);
@@ -83,4 +84,10 @@ final class UuidV7Generator implements IdGenerator {
 
     return new UUID(msb, lsb);
   }
+
+  @Override
+  protected void startUp() throws Exception {}
+
+  @Override
+  protected void shutDown() throws Exception {}
 }

--- a/common/src/test/java/com/larpconnect/njall/common/id/UuidV7GeneratorServiceTest.java
+++ b/common/src/test/java/com/larpconnect/njall/common/id/UuidV7GeneratorServiceTest.java
@@ -14,7 +14,7 @@ import java.util.random.RandomGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-final class UuidV7GeneratorTest {
+final class UuidV7GeneratorServiceTest {
 
   private static final class FakeTimeService extends AbstractIdleService implements TimeService {
     long timeMs = 1000L;
@@ -48,14 +48,15 @@ final class UuidV7GeneratorTest {
 
   private FakeTimeService fakeTimeService;
   private FakeRandomGenerator fakeRandom;
-  private UuidV7Generator generator;
+  private UuidV7GeneratorService generator;
 
   @BeforeEach
   void setUp() {
     fakeTimeService = new FakeTimeService();
     fakeRandom = new FakeRandomGenerator();
     Provider<RandomGenerator> randomProvider = () -> fakeRandom;
-    generator = new UuidV7Generator(fakeTimeService, randomProvider);
+    generator = new UuidV7GeneratorService(fakeTimeService, randomProvider);
+    generator.startAsync().awaitRunning();
   }
 
   @Test
@@ -142,7 +143,8 @@ final class UuidV7GeneratorTest {
   void generate_concurrent_success() throws InterruptedException {
     fakeTimeService.timeMs = 2000L;
 
-    generator = new UuidV7Generator(fakeTimeService, ThreadLocalRandom::current);
+    generator = new UuidV7GeneratorService(fakeTimeService, ThreadLocalRandom::current);
+    generator.startAsync().awaitRunning();
 
     int numThreads = 10;
     int numIdsPerThread = 1000;


### PR DESCRIPTION
Following the `.agents/skills/design-patterns.md`, this splits
the `IdGenerator` into an `IdGenerator`, an `IdGeneratorService`, and
a final `UuidV7GeneratorService` implementation extending `AbstractIdleService`.

Tests and Guice bindings were updated to match the new structure and
handle asynchronous service initialization via `startAsync().awaitRunning()`.

---
*PR created automatically by Jules for task [3029868527290496323](https://jules.google.com/task/3029868527290496323) started by @dclements*