### PR TITLE
ArchUnit fixes for exemptions

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
@@ -1,6 +1,7 @@
 package com.larpconnect.njall.common;
 
 import com.google.inject.AbstractModule;
+import com.larpconnect.njall.common.codec.CodecModule;
 import com.larpconnect.njall.common.id.IdModule;
 import com.larpconnect.njall.common.time.TimeModule;
 
@@ -11,5 +12,6 @@ public final class CommonModule extends AbstractModule {
   protected void configure() {
     install(new TimeModule());
     install(new IdModule());
+    install(new CodecModule());
   }
 }

--- a/common/src/main/java/com/larpconnect/njall/common/codec/CodecBindingModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/CodecBindingModule.java
@@ -1,0 +1,17 @@
+package com.larpconnect.njall.common.codec;
+
+import com.google.inject.AbstractModule;
+import com.larpconnect.njall.common.annotations.InstallInstead;
+
+@InstallInstead(CodecModule.class)
+final class CodecBindingModule extends AbstractModule {
+  CodecBindingModule() {}
+
+  @Override
+  protected void configure() {
+    bind(new com.google.inject.TypeLiteral<
+            io.vertx.core.eventbus.MessageCodec<
+                com.larpconnect.njall.proto.Message, com.larpconnect.njall.proto.Message>>() {})
+        .to(ProtoCodecRegistry.class);
+  }
+}

--- a/common/src/main/java/com/larpconnect/njall/common/codec/CodecModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/CodecModule.java
@@ -1,0 +1,12 @@
+package com.larpconnect.njall.common.codec;
+
+import com.google.inject.AbstractModule;
+
+public final class CodecModule extends AbstractModule {
+  public CodecModule() {}
+
+  @Override
+  protected void configure() {
+    install(new CodecBindingModule());
+  }
+}

--- a/common/src/main/java/com/larpconnect/njall/common/codec/ProtoCodecRegistry.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/ProtoCodecRegistry.java
@@ -20,11 +20,13 @@ import io.vertx.core.eventbus.MessageCodec;
  * using protobuf rather than JSON to minimize payload size and reduce bandwidth consumption.
  */
 @Immutable
-public final class ProtoCodecRegistry implements MessageCodec<Message, Message> {
+@jakarta.inject.Singleton
+final class ProtoCodecRegistry implements MessageCodec<Message, Message> {
   private static final short VERSION = 0x01;
   private static final int INT_SIZE = 4;
   private static final String NAMESPACE = "com.larpconnect.njall.proto.";
 
+  @jakarta.inject.Inject
   public ProtoCodecRegistry() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/UuidV7Generator.java
@@ -38,6 +38,7 @@ final class UuidV7Generator implements IdGenerator {
   private final Provider<RandomGenerator> randomProvider;
   private final AtomicReference<State> state;
 
+  @com.google.errorprone.annotations.Immutable
   private record State(long timeMs, long counter) {}
 
   @Inject

--- a/common/src/test/java/com/larpconnect/njall/common/verticle/AbstractLcVerticleTest.java
+++ b/common/src/test/java/com/larpconnect/njall/common/verticle/AbstractLcVerticleTest.java
@@ -2,12 +2,16 @@ package com.larpconnect.njall.common.verticle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.inject.Guice;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
 import com.google.protobuf.ByteString;
-import com.larpconnect.njall.common.codec.ProtoCodecRegistry;
+import com.larpconnect.njall.common.codec.CodecModule;
 import com.larpconnect.njall.common.id.IdGenerator;
 import com.larpconnect.njall.proto.Message;
 import com.larpconnect.njall.proto.Observability;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import jakarta.inject.Provider;
@@ -31,7 +35,10 @@ final class AbstractLcVerticleTest {
   @BeforeEach
   void setUp(VertxTestContext testContext) {
     vertx = Vertx.vertx();
-    vertx.eventBus().registerDefaultCodec(Message.class, new ProtoCodecRegistry());
+    MessageCodec<Message, Message> codec =
+        Guice.createInjector(new CodecModule())
+            .getInstance(Key.get(new TypeLiteral<MessageCodec<Message, Message>>() {}));
+    vertx.eventBus().registerDefaultCodec(Message.class, codec);
     testContext.completeNow();
   }
 

--- a/init/src/main/java/com/larpconnect/njall/init/VerticleSetupService.java
+++ b/init/src/main/java/com/larpconnect/njall/init/VerticleSetupService.java
@@ -4,10 +4,10 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.inject.Injector;
 import com.larpconnect.njall.common.annotations.AiContract;
-import com.larpconnect.njall.common.codec.ProtoCodecRegistry;
 import com.larpconnect.njall.proto.Message;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageCodec;
 import jakarta.inject.Inject;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
@@ -17,8 +17,11 @@ final class VerticleSetupService {
   private final Logger logger = LoggerFactory.getLogger(VerticleSetupService.class);
   private final AtomicReference<Vertx> vertxRef = new AtomicReference<>();
 
+  private final MessageCodec<Message, Message> protoCodecRegistry;
+
   @Inject
-  VerticleSetupService(ProtoCodecRegistry protoCodecRegistry) {
+  VerticleSetupService(MessageCodec<Message, Message> protoCodecRegistry) {
+    this.protoCodecRegistry = protoCodecRegistry;
     logger.info("Loaded ProtoCodecRegistry: {}", protoCodecRegistry);
   }
 
@@ -32,7 +35,7 @@ final class VerticleSetupService {
       implementationHint = "Registers Guice verticle factory and Proto codec.")
   void setup(Vertx vertx, Injector injector) {
     vertx.registerVerticleFactory(new GuiceVerticleFactory(injector));
-    vertx.eventBus().registerDefaultCodec(Message.class, new ProtoCodecRegistry());
+    vertx.eventBus().registerDefaultCodec(Message.class, this.protoCodecRegistry);
     vertxRef.set(vertx);
   }
 

--- a/init/src/test/java/com/larpconnect/njall/init/VerticleLifecycleTest.java
+++ b/init/src/test/java/com/larpconnect/njall/init/VerticleLifecycleTest.java
@@ -15,7 +15,9 @@ final class VerticleLifecycleTest {
 
   @Test
   public void startUp_validConfig_success() throws Exception {
-    var lifecycle = VerticleServices.create(ImmutableList.of());
+    var lifecycle =
+        VerticleServices.create(
+            ImmutableList.of(new com.larpconnect.njall.common.codec.CodecModule()));
 
     lifecycle.startAsync().awaitRunning(10, TimeUnit.SECONDS);
     assertThat(lifecycle.isRunning()).isTrue();
@@ -30,7 +32,9 @@ final class VerticleLifecycleTest {
   public void startUp_missingConfig_throwsRuntimeException() {
     System.setProperty("njall.config.resource", "missing.json");
     try {
-      var lifecycle = VerticleServices.create(ImmutableList.of());
+      var lifecycle =
+          VerticleServices.create(
+              ImmutableList.of(new com.larpconnect.njall.common.codec.CodecModule()));
       assertThatThrownBy(() -> lifecycle.startAsync().awaitRunning(10, TimeUnit.SECONDS))
           .isInstanceOf(IllegalStateException.class);
     } finally {

--- a/init/src/test/java/com/larpconnect/njall/init/VerticleSetupServiceTest.java
+++ b/init/src/test/java/com/larpconnect/njall/init/VerticleSetupServiceTest.java
@@ -8,12 +8,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.larpconnect.njall.common.codec.ProtoCodecRegistry;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.larpconnect.njall.common.codec.CodecModule;
+import com.larpconnect.njall.proto.Message;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.MessageCodec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +36,10 @@ final class VerticleSetupServiceTest {
     mockInjector = mock(Injector.class);
     when(mockVertx.eventBus()).thenReturn(mockEventBus);
     when(mockEventBus.registerDefaultCodec(any(), any())).thenReturn(mockEventBus);
-    service = new VerticleSetupService(new ProtoCodecRegistry());
+    MessageCodec<Message, Message> codec =
+        Guice.createInjector(new CodecModule())
+            .getInstance(Key.get(new TypeLiteral<MessageCodec<Message, Message>>() {}));
+    service = new VerticleSetupService(codec);
   }
 
   @Test

--- a/integration/src/test/java/com/larpconnect/njall/integration/arch/ArchitectureTest.java
+++ b/integration/src/test/java/com/larpconnect/njall/integration/arch/ArchitectureTest.java
@@ -66,10 +66,6 @@ final class ArchitectureTest {
           .areNotAnonymousClasses()
           .and()
           .resideOutsideOfPackage("com.larpconnect.njall.proto..")
-          .and()
-          .resideOutsideOfPackage("com.larpconnect.njall.api..")
-          .and()
-          .resideOutsideOfPackage("com.larpconnect.njall.common.codec..")
           .should()
           .haveModifier(JavaModifier.ABSTRACT)
           .orShould()
@@ -89,10 +85,6 @@ final class ArchitectureTest {
           .areNotAssignableTo(Module.class)
           .and()
           .resideOutsideOfPackage("com.larpconnect.njall.proto..")
-          .and()
-          .resideOutsideOfPackage("com.larpconnect.njall.api..")
-          .and()
-          .resideOutsideOfPackage("com.larpconnect.njall.common.codec..")
           .should()
           .notBePublic();
 
@@ -204,4 +196,13 @@ final class ArchitectureTest {
                 }
               })
           .allowEmptyShould(true);
+
+  // 8. All record classes must be annotated with @Immutable.
+  @ArchTest
+  public static final ArchRule records_must_be_annotated_immutable =
+      classes()
+          .that()
+          .areRecords()
+          .should()
+          .beAnnotatedWith(com.google.errorprone.annotations.Immutable.class);
 }


### PR DESCRIPTION
1. Added `records_must_be_annotated_immutable` rule to `ArchitectureTest` and applied `@Immutable` to `UuidV7Generator.State`.
2. Removed exemptions for `com.larpconnect.njall.api..` and `com.larpconnect.njall.common.codec..` from `classes_must_be_abstract_or_final` and `non_module_classes_should_not_be_public`.
3. Updated `ApiObjectParser` to be package-private for implementations.
4. Created Guice `CodecModule` and `CodecBindingModule` to provide `MessageCodec<Message, Message>` as the interface instead of `ProtoCodecRegistry` class.
5. Refactored `ProtoCodecRegistry` to a package-private final class.

---
*PR created automatically by Jules for task [10574303543850234839](https://jules.google.com/task/10574303543850234839) started by @dclements*