### PR TITLE
🚧 Pentiousinator: Alphabetize and deduplicate gradle dependencies

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -5,7 +5,5 @@ plugins {
 dependencies {
     api(project(":proto"))
     implementation(project(":common"))
-    implementation(libs.vertx.core)
     implementation(libs.protobuf.java.util)
-    implementation(libs.guice)
 }

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -6,8 +6,8 @@ dependencies {
     constraints {
         api(project(":api"))
         api(project(":common"))
-        api(project(":integration"))
         api(project(":init"))
+        api(project(":integration"))
         api(project(":parent"))
         api(project(":proto"))
         api(project(":server"))


### PR DESCRIPTION
💡 What was changed:
- Removed duplicate `libs.vertx.core` and `libs.guice` dependencies from `api/build.gradle.kts` as they are already exposed via `api` in the `:parent` project (which `api` depends on).
- Alphabetized the project constraints in `bom/build.gradle.kts` so that `:init` properly comes before `:integration`.

🎯 Why it helps make the build system better:
It ensures that the build files respect the coding standards outlined in `.agents/skills/gradle.md` regarding dependency ordering. Deduplicating dependencies from the `api` module reduces redundancy and makes it clearer what truly needs to be explicitly imported vs what is available via the core `parent` module's API.

---
*PR created automatically by Jules for task [10578449214631276598](https://jules.google.com/task/10578449214631276598) started by @dclements*