### PR TITLE
📄 Nihiluxinator: Add missing javadocs to MessageResponse and TimeService

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/verticle/MessageResponse.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/MessageResponse.java
@@ -1,3 +1,11 @@
 package com.larpconnect.njall.api.verticle;
 
+/**
+ * A sealed interface representing the outcome of handling a message over the Vert.x EventBus.
+ *
+ * <p>By requiring handlers to return a structured response rather than interacting with the message
+ * directly, the framework abstracts control flow (such as replying or unregistering a consumer)
+ * away from the business logic. This decouples verticles from the underlying EventBus mechanics,
+ * making handlers easier to test and preventing accidental misuse of the raw Vert.x APIs.
+ */
 public sealed interface MessageResponse permits BasicResponse, ReplyResponse {}

--- a/common/src/main/java/com/larpconnect/njall/common/time/TimeService.java
+++ b/common/src/main/java/com/larpconnect/njall/common/time/TimeService.java
@@ -5,5 +5,11 @@ import com.google.common.util.concurrent.Service;
 /**
  * A service interface extending {@link MonotonicClock} and {@link Service} to manage the lifecycle
  * of the temporal operations provider.
+ *
+ * <p>Following the Single Implementation Interface pattern, this interface bridges the base {@code
+ * MonotonicClock} capability with Guava's state management. This ensures that the clock can be
+ * properly started during Guice's synchronous initialization phase, guaranteeing the availability
+ * of a stable clock source across the application before any asynchronous Vert.x components
+ * execute.
  */
 public interface TimeService extends MonotonicClock, Service {}


### PR DESCRIPTION
💡 What was changed:
Added detailed, explanatory Javadocs to the `MessageResponse` sealed interface and the `TimeService` interface.

Consistency edits that were needed:
No consistency edits were needed across other files; the modifications applied only to these two interface definitions.

🎯 Why the documentation is helpful:
The original documentation for these files was either missing entirely (`MessageResponse`) or only described *what* the interface did (`TimeService`). The new documentation focuses on the *why* - explaining that `MessageResponse` exists to decouple Vert.x EventBus mechanics from business logic, and that `TimeService` exists to bridge Guava state management with a clock source for Guice's synchronous initialization phase. This context provides a stronger architectural understanding for future developers and agents.

---
*PR created automatically by Jules for task [4690089377309225116](https://jules.google.com/task/4690089377309225116) started by @dclements*