### PR TITLE
🧪 Add test for GuiceVerticleFactory ClassCastException

### DIFF
--- a/init/src/test/java/com/larpconnect/njall/init/GuiceVerticleFactoryTest.java
+++ b/init/src/test/java/com/larpconnect/njall/init/GuiceVerticleFactoryTest.java
@@ -20,6 +20,8 @@ final class GuiceVerticleFactoryTest {
 
   static final class TestVerticle extends AbstractVerticle {}
 
+  static final class NonVerticleClass {}
+
   @Test
   public void createVerticle_validClass_success(VertxTestContext testContext) {
     Injector injector =
@@ -74,6 +76,35 @@ final class GuiceVerticleFactoryTest {
                     assertThat(e)
                         .isInstanceOf(IllegalArgumentException.class)
                         .hasMessageContaining("Failed to load verticle class");
+                    testContext.completeNow();
+                  } catch (Exception e) {
+                    testContext.failNow(e);
+                  }
+                }));
+  }
+
+  @Test
+  public void createVerticle_nonVerticleClass_failure(VertxTestContext testContext) {
+    Injector injector = Guice.createInjector(new com.larpconnect.njall.common.CommonModule());
+    var factory = new GuiceVerticleFactory(injector);
+
+    Promise<Callable<Verticle>> promise = Promise.promise();
+    factory.createVerticle(
+        "guice:" + NonVerticleClass.class.getName(), getClass().getClassLoader(), promise);
+
+    promise
+        .future()
+        .onComplete(
+            testContext.succeeding(
+                callable -> {
+                  try {
+                    callable.call();
+                    testContext.failNow("Expected IllegalArgumentException was not thrown");
+                  } catch (IllegalArgumentException e) {
+                    assertThat(e)
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("Failed to load verticle class")
+                        .hasCauseInstanceOf(ClassCastException.class);
                     testContext.completeNow();
                   } catch (Exception e) {
                     testContext.failNow(e);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
A test was missing to verify the scenario where `GuiceVerticleFactory` attempts to load a valid class that does not implement the `Verticle` interface, triggering a `ClassCastException` inside its internal supplier logic.

📊 **Coverage:** What scenarios are now tested
The new `createVerticle_nonVerticleClass_failure` test directly covers the exception handling branch in `GuiceVerticleFactory.createVerticle`.

✨ **Result:** The improvement in test coverage
The `GuiceVerticleFactory` initialization now correctly validates logic when incorrectly bound Guice dependencies are passed via Vertx.

---
*PR created automatically by Jules for task [16595791722246900636](https://jules.google.com/task/16595791722246900636) started by @dclements*