### PR TITLE
🧹 Replace deprecated createVerticle with createVerticle2

### DIFF
--- a/init/src/main/java/com/larpconnect/njall/init/GuiceVerticleFactory.java
+++ b/init/src/main/java/com/larpconnect/njall/init/GuiceVerticleFactory.java
@@ -4,6 +4,7 @@ import static com.larpconnect.njall.common.annotations.ContractTag.PURE;
 
 import com.google.inject.Injector;
 import com.larpconnect.njall.common.annotations.AiContract;
+import io.vertx.core.Deployable;
 import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.core.spi.VerticleFactory;
@@ -24,14 +25,15 @@ final class GuiceVerticleFactory implements VerticleFactory {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
   @AiContract(
       require = {"verticleName \\neq \\bot", "classLoader \\neq \\bot", "promise \\neq \\bot"},
       ensure = "promise \\text{ is completed with a Verticle factory}",
       implementationHint =
           "Resolves and instantiates the Verticle using the Guice injector by class name.")
-  public void createVerticle(
-      String verticleName, ClassLoader classLoader, Promise<Callable<Verticle>> promise) {
+  public void createVerticle2(
+      String verticleName,
+      ClassLoader classLoader,
+      Promise<Callable<? extends Deployable>> promise) {
     var clazzName = VerticleFactory.removePrefix(verticleName);
     promise.complete(
         () -> {

--- a/init/src/test/java/com/larpconnect/njall/init/GuiceVerticleFactoryTest.java
+++ b/init/src/test/java/com/larpconnect/njall/init/GuiceVerticleFactoryTest.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Deployable;
 import io.vertx.core.Promise;
 import io.vertx.core.Verticle;
 import io.vertx.junit5.VertxExtension;
@@ -35,8 +36,8 @@ final class GuiceVerticleFactoryTest {
     var factory = new GuiceVerticleFactory(injector);
     assertThat(factory.prefix()).isEqualTo("guice");
 
-    Promise<Callable<Verticle>> promise = Promise.promise();
-    factory.createVerticle(
+    Promise<Callable<? extends Deployable>> promise = Promise.promise();
+    factory.createVerticle2(
         "guice:" + TestVerticle.class.getName(), getClass().getClassLoader(), promise);
 
     promise
@@ -45,7 +46,7 @@ final class GuiceVerticleFactoryTest {
             testContext.succeeding(
                 callable -> {
                   try {
-                    Verticle verticle = callable.call();
+                    Verticle verticle = (Verticle) callable.call();
                     assertThat(verticle).isInstanceOf(TestVerticle.class);
                     testContext.completeNow();
                   } catch (Exception e) { // Callable throws Exception
@@ -59,8 +60,8 @@ final class GuiceVerticleFactoryTest {
     Injector injector = Guice.createInjector(new com.larpconnect.njall.common.CommonModule());
     var factory = new GuiceVerticleFactory(injector);
 
-    Promise<Callable<Verticle>> promise = Promise.promise();
-    factory.createVerticle("guice:com.example.MissingClass", getClass().getClassLoader(), promise);
+    Promise<Callable<? extends Deployable>> promise = Promise.promise();
+    factory.createVerticle2("guice:com.example.MissingClass", getClass().getClassLoader(), promise);
 
     promise
         .future()


### PR DESCRIPTION
🎯 **What:** The `GuiceVerticleFactory` was using the deprecated `createVerticle` method to return a `Promise<Callable<Verticle>>`. It now uses `createVerticle2` and returns a `Promise<Callable<? extends Deployable>>`.
💡 **Why:** This ensures full compatibility with Vert.x 5's API expectations and prevents future breakages when `createVerticle` is eventually removed. It improves code health by eliminating `@SuppressWarnings("deprecation")`.
✅ **Verification:** Verified by running `./gradlew spotlessApply check build` to confirm no formatting, style, or runtime regressions. Unit tests were specifically updated and verified.
✨ **Result:** A cleaner codebase aligned with current Vert.x conventions without any loss of functionality.

---
*PR created automatically by Jules for task [16632848544236352596](https://jules.google.com/task/16632848544236352596) started by @dclements*