### PR TITLE
fix: Delegate Webfinger endpoint to WebfingerVerticle over EventBus

### DIFF
--- a/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
+++ b/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
@@ -163,7 +163,35 @@ final class WebServerVerticle extends AbstractVerticle {
       ensure = "ctx.response() \\text{ contains JSON Webfinger response}",
       implementationHint = "Returns a valid JSON response for a webfinger query")
   void handleWebfinger(RoutingContext ctx) {
-    var response = new JsonObject().put("subject", "acct:system@localhost");
-    ctx.json(response);
+    var requestBuilder = MessageRequest.newBuilder();
+    ctx.queryParams()
+        .forEach(
+            (key, value) -> {
+              requestBuilder.addParameters(
+                  com.larpconnect.njall.proto.Parameter.newBuilder()
+                      .setKey(key)
+                      .setStringValue(value)
+                      .build());
+            });
+
+    vertx
+        .eventBus()
+        .<com.larpconnect.njall.proto.WebfingerResponse>request(
+            "http.well-known.webfinger.request", requestBuilder.build())
+        .onSuccess(
+            msg -> {
+              try {
+                String json = PRINTER.print(msg.body());
+                ctx.json(new JsonObject(json));
+              } catch (IOException e) {
+                logger.error("Failed to serialize webfinger response", e);
+                ctx.fail(java.net.HttpURLConnection.HTTP_INTERNAL_ERROR, e);
+              }
+            })
+        .onFailure(
+            e -> {
+              logger.error("Webfinger request failed", e);
+              ctx.fail(java.net.HttpURLConnection.HTTP_INTERNAL_ERROR, e);
+            });
   }
 }

--- a/server/src/test/java/com/larpconnect/njall/server/WebServerVerticleTest.java
+++ b/server/src/test/java/com/larpconnect/njall/server/WebServerVerticleTest.java
@@ -2,6 +2,8 @@ package com.larpconnect.njall.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.larpconnect.njall.proto.MessageRequest;
+import com.larpconnect.njall.proto.WebfingerResponse;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -51,7 +53,15 @@ final class WebServerVerticleTest {
   }
 
   @Test
-  void webfingerEndpoint_succeeds_withSubject(VertxTestContext testContext) {
+  void webfingerEndpoint_succeeds_withSubject(Vertx vertx, VertxTestContext testContext) {
+    vertx
+        .eventBus()
+        .<MessageRequest>consumer(
+            "http.well-known.webfinger.request",
+            msg -> {
+              msg.reply(WebfingerResponse.newBuilder().setSubject("acct:system@localhost").build());
+            });
+
     webClient
         .get("/.well-known/webfinger")
         .send()
@@ -61,7 +71,8 @@ final class WebServerVerticleTest {
                     testContext.verify(
                         () -> {
                           assertThat(response.statusCode()).isEqualTo(200);
-                          assertThat(response.bodyAsJsonObject().containsKey("subject")).isTrue();
+                          assertThat(response.bodyAsJsonObject().getString("subject"))
+                              .isEqualTo("acct:system@localhost");
                           testContext.completeNow();
                         })));
   }


### PR DESCRIPTION
Changes WebServerVerticle to build a MessageRequest containing the query
parameters and send it over the event bus instead of replying with a static
hardcoded JSON response. Fixes the associated test to mock the event bus
response.

---
*PR created automatically by Jules for task [12153028761665882142](https://jules.google.com/task/12153028761665882142) started by @dclements*