### PR TITLE
📄 Nihiluxinator: Add missing Javadocs to public Guice modules

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
@@ -5,6 +5,10 @@ import com.larpconnect.njall.common.codec.CodecModule;
 import com.larpconnect.njall.common.id.IdModule;
 import com.larpconnect.njall.common.time.TimeModule;
 
+/**
+ * Guice module that provides common utilities and core infrastructure for the system, including
+ * time services, ID generation, and EventBus codecs.
+ */
 public final class CommonModule extends AbstractModule {
   public CommonModule() {}
 

--- a/common/src/main/java/com/larpconnect/njall/common/codec/CodecModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/CodecModule.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.common.codec;
 
 import com.google.inject.AbstractModule;
 
+/** Guice module responsible for registering Protocol Buffer codecs for the Vert.x EventBus. */
 public final class CodecModule extends AbstractModule {
   public CodecModule() {}
 

--- a/common/src/main/java/com/larpconnect/njall/common/id/IdModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdModule.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.common.id;
 
 import com.google.inject.AbstractModule;
 
+/** Guice module responsible for providing unique identifier generation capabilities. */
 public final class IdModule extends AbstractModule {
   public IdModule() {}
 

--- a/common/src/main/java/com/larpconnect/njall/common/time/TimeModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/time/TimeModule.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.common.time;
 
 import com.google.inject.AbstractModule;
 
+/** Guice module responsible for providing time-related services and monotonic clocks. */
 public final class TimeModule extends AbstractModule {
   public TimeModule() {}
 

--- a/init/src/main/java/com/larpconnect/njall/init/InitModule.java
+++ b/init/src/main/java/com/larpconnect/njall/init/InitModule.java
@@ -2,6 +2,10 @@ package com.larpconnect.njall.init;
 
 import com.google.inject.AbstractModule;
 
+/**
+ * Guice module responsible for providing application initialization, configuration, and Verticle
+ * deployment services.
+ */
 public final class InitModule extends AbstractModule {
   public InitModule() {}
 

--- a/server/src/main/java/com/larpconnect/njall/server/ServerModule.java
+++ b/server/src/main/java/com/larpconnect/njall/server/ServerModule.java
@@ -5,6 +5,10 @@ import com.larpconnect.njall.api.ApiModule;
 import com.larpconnect.njall.common.CommonModule;
 import com.larpconnect.njall.init.InitModule;
 
+/**
+ * The main entry point Guice module that wires together the server infrastructure, integrating the
+ * API, common utilities, and initialization components.
+ */
 public final class ServerModule extends AbstractModule {
   public ServerModule() {}
 


### PR DESCRIPTION
💡 What was changed:
Added descriptive Javadoc comments to the public Guice modules (`CommonModule`, `IdModule`, `TimeModule`, `CodecModule`, `InitModule`, `ServerModule`). 

Consistency edits that were needed:
Ensured that all public module classes across the multimodule Gradle build have Javadocs explaining their purpose and what they install, matching the existing standard seen in `ApiModule` and `ApiVerticleModule`.

🎯 Why the documentation is helpful:
Public classes require comprehensive Javadocs per `AGENTS.md` and `AI_POLICY.md` standards. Providing these comments helps developers and AIs understand the architectural boundaries and the specific role of each module within the Guice dependency injection graph without having to read the implementation details.

---
*PR created automatically by Jules for task [18197136046288554329](https://jules.google.com/task/18197136046288554329) started by @dclements*