### PR TITLE
🪳 Nifftyinator: CLEAN! IT! UP!

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/verticle/AbstractLcVerticle.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/AbstractLcVerticle.java
@@ -92,7 +92,7 @@ abstract class AbstractLcVerticle extends AbstractVerticle {
                   vertx.eventBus().consumer(channel).unregister();
                 }
               } catch (IOException e) {
-                // Closer does not throw IOException in this context
+                throw new java.io.UncheckedIOException(e);
               } catch (RuntimeException e) {
                 log.error("Error handling message on channel: {}", channel, e);
                 msg.fail(-1, "Internal Error");

--- a/api/src/main/java/com/larpconnect/njall/api/verticle/WebfingerVerticle.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/WebfingerVerticle.java
@@ -37,7 +37,7 @@ final class WebfingerVerticle extends AbstractLcVerticle {
     }
 
     // Do not return made-up data. Just echo the subject without fake data.
-    WebfingerResponse response = WebfingerResponse.newBuilder().setSubject(resource).build();
+    var response = WebfingerResponse.newBuilder().setSubject(resource).build();
     responsePromise.complete(response);
 
     return BasicResponse.CONTINUE;

--- a/api/src/test/java/com/larpconnect/njall/api/DefaultApiObjectParserTest.java
+++ b/api/src/test/java/com/larpconnect/njall/api/DefaultApiObjectParserTest.java
@@ -53,7 +53,7 @@ final class DefaultApiObjectParserTest {
             .putExtensions("unknown", Extension.getDefaultInstance()) // empty extension test
             .build();
 
-    JsonObject json = parser.toJson(obj);
+    var json = parser.toJson(obj);
 
     assertThat(json.getJsonArray("context"))
         .containsExactly("https://www.w3.org/ns/activitystreams", "https://example.com/other");
@@ -69,8 +69,8 @@ final class DefaultApiObjectParserTest {
 
   @Test
   void toJson_handlesEmptyObject_successfully() {
-    ApiObject obj = ApiObject.getDefaultInstance();
-    JsonObject json = parser.toJson(obj);
+    var obj = ApiObject.getDefaultInstance();
+    var json = parser.toJson(obj);
     assertThat(json.isEmpty()).isTrue();
   }
 
@@ -92,7 +92,7 @@ final class DefaultApiObjectParserTest {
                     .build())
             .build();
 
-    JsonObject json = parser.toJson(obj);
+    var json = parser.toJson(obj);
     assertThat(json.getString("media_type")).isEqualTo("image/png");
     assertThat(json.getString("content")).isEqualTo("aGVsbG8gd29ybGQ=");
   }
@@ -136,7 +136,7 @@ final class DefaultApiObjectParserTest {
             .put("href", "https://example.com/href")
             .put("total_items", "42");
 
-    ApiObject obj = parser.fromJson(json);
+    var obj = parser.fromJson(json);
 
     assertThat(obj.getContextList())
         .containsExactly("https://www.w3.org/ns/activitystreams", "other");
@@ -172,7 +172,7 @@ final class DefaultApiObjectParserTest {
             .put("media_type", "image/png")
             .put("content", "aGVsbG8gd29ybGQ=");
 
-    ApiObject obj = parser.fromJson(json);
+    var obj = parser.fromJson(json);
     assertThat(obj.getExtensionsMap().get("document").getDocument().getContent().toStringUtf8())
         .isEqualTo("hello world");
   }
@@ -185,7 +185,7 @@ final class DefaultApiObjectParserTest {
             .put("mediaType", "text/plain")
             .put("content", "hello camel case");
 
-    ApiObject obj = parser.fromJson(json);
+    var obj = parser.fromJson(json);
     assertThat(obj.getExtensionsMap().get("document").getDocument().getContent().toStringUtf8())
         .isEqualTo("hello camel case");
   }
@@ -197,7 +197,7 @@ final class DefaultApiObjectParserTest {
             .put("type", new JsonArray().add("Document"))
             .put("media_type", "text/plain");
 
-    ApiObject obj = parser.fromJson(json);
+    var obj = parser.fromJson(json);
     assertThat(obj.getExtensionsMap().get("document").getDocument().getMediaType())
         .isEqualTo("text/plain");
   }
@@ -209,14 +209,14 @@ final class DefaultApiObjectParserTest {
             .put("type", new JsonArray().add("Document"))
             .put("content", "aGVsbG8="); // requires base64 because mediaType is not text/plain
 
-    ApiObject obj = parser.fromJson(json);
+    var obj = parser.fromJson(json);
     assertThat(obj.getExtensionsMap().get("document").getDocument().getContent().toStringUtf8())
         .isEqualTo("hello");
   }
 
   @Test
   void fromJson_handlesEmptyObject_successfully() {
-    ApiObject obj = parser.fromJson(new JsonObject());
+    var obj = parser.fromJson(new JsonObject());
     assertThat(obj.getId()).isEmpty();
   }
 
@@ -229,7 +229,7 @@ final class DefaultApiObjectParserTest {
             .put("deleted", "2023-01-01T00:00:00Z")
             .put("media_type", "text/plain");
 
-    ApiObject obj = parser.fromJson(json);
+    var obj = parser.fromJson(json);
     assertThat(obj.getExtensionsMap()).isEmpty();
   }
 

--- a/api/src/test/java/com/larpconnect/njall/api/verticle/AbstractLcVerticleTest.java
+++ b/api/src/test/java/com/larpconnect/njall/api/verticle/AbstractLcVerticleTest.java
@@ -88,7 +88,7 @@ final class AbstractLcVerticleTest {
                           .setTraceId(com.google.protobuf.ByteString.copyFrom(originalTraceId))
                           .setSpanId(com.google.protobuf.ByteString.copyFrom(originalSpanId))
                           .build();
-                  MessageRequest message = MessageRequest.newBuilder().setTraceparent(obs).build();
+                  var message = MessageRequest.newBuilder().setTraceparent(obs).build();
 
                   vertx.eventBus().send(CHANNEL, message);
 
@@ -146,7 +146,7 @@ final class AbstractLcVerticleTest {
         .onComplete(
             testContext.succeeding(
                 id -> {
-                  MessageRequest message = MessageRequest.newBuilder().build();
+                  var message = MessageRequest.newBuilder().build();
 
                   vertx
                       .eventBus()
@@ -205,7 +205,7 @@ final class AbstractLcVerticleTest {
         .onComplete(
             testContext.succeeding(
                 id -> {
-                  MessageRequest message = MessageRequest.newBuilder().build();
+                  var message = MessageRequest.newBuilder().build();
 
                   vertx
                       .eventBus()
@@ -267,7 +267,7 @@ final class AbstractLcVerticleTest {
         .onComplete(
             testContext.succeeding(
                 id -> {
-                  MessageRequest message = MessageRequest.newBuilder().build(); // No traceparent
+                  var message = MessageRequest.newBuilder().build(); // No traceparent
 
                   vertx.eventBus().send(CHANNEL, message);
 
@@ -334,7 +334,7 @@ final class AbstractLcVerticleTest {
                 id -> {
                   Observability obs =
                       Observability.newBuilder().build(); // Empty traceId and spanId
-                  MessageRequest message = MessageRequest.newBuilder().setTraceparent(obs).build();
+                  var message = MessageRequest.newBuilder().setTraceparent(obs).build();
 
                   vertx.eventBus().send(CHANNEL, message);
 
@@ -399,7 +399,7 @@ final class AbstractLcVerticleTest {
         .onComplete(
             testContext.succeeding(
                 id -> {
-                  MessageRequest message = MessageRequest.newBuilder().build(); // No traceparent
+                  var message = MessageRequest.newBuilder().build(); // No traceparent
 
                   vertx.eventBus().send(CHANNEL, message);
 
@@ -459,7 +459,7 @@ final class AbstractLcVerticleTest {
         .onComplete(
             testContext.succeeding(
                 id -> {
-                  MessageRequest message = MessageRequest.newBuilder().build(); // No traceparent
+                  var message = MessageRequest.newBuilder().build(); // No traceparent
 
                   vertx
                       .eventBus()


### PR DESCRIPTION
💡 What was changed
* Used `var` for implicitly typed local variables across `AbstractLcVerticleTest`, `DefaultApiObjectParserTest`, and `WebfingerVerticle`.
* Modified `AbstractLcVerticle` to wrap `IOException` in an `UncheckedIOException` and safely rethrow it, rather than silently swallowing it with a comment.

Consistency edits that were needed
* Checked if Guice module constructors should be made package-private, but reverted the attempt as it broke the Guice multi-module structure where test modules load other sub-modules.

---
*PR created automatically by Jules for task [7830715932349631516](https://jules.google.com/task/7830715932349631516) started by @dclements*