### PR TITLE
feat: return MessageReply from AbstractLcVerticle

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/verticle/AbstractLcVerticle.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/AbstractLcVerticle.java
@@ -3,8 +3,8 @@ package com.larpconnect.njall.api.verticle;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.Closer;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Message;
 import com.larpconnect.njall.common.id.IdGenerator;
+import com.larpconnect.njall.proto.MessageReply;
 import com.larpconnect.njall.proto.MessageRequest;
 import com.larpconnect.njall.proto.Observability;
 import io.vertx.core.AbstractVerticle;
@@ -74,7 +74,7 @@ abstract class AbstractLcVerticle extends AbstractVerticle {
                 closer.register(MDC.putCloseable("parent_span_id", parentSpanIdStr));
                 closer.register(MDC.putCloseable("span_id", spanIdStr));
 
-                Promise<Message> responsePromise = Promise.promise();
+                Promise<MessageReply> responsePromise = Promise.promise();
                 responsePromise
                     .future()
                     .onComplete(
@@ -127,5 +127,5 @@ abstract class AbstractLcVerticle extends AbstractVerticle {
   }
 
   protected abstract MessageResponse handleMessage(
-      byte[] spanId, MessageRequest message, Promise<Message> responsePromise);
+      byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise);
 }

--- a/api/src/main/java/com/larpconnect/njall/api/verticle/WebfingerVerticle.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/WebfingerVerticle.java
@@ -1,9 +1,11 @@
 package com.larpconnect.njall.api.verticle;
 
-import com.google.protobuf.Message;
+import com.google.protobuf.Any;
 import com.larpconnect.njall.common.id.IdGenerator;
+import com.larpconnect.njall.proto.MessageReply;
 import com.larpconnect.njall.proto.MessageRequest;
 import com.larpconnect.njall.proto.Parameter;
+import com.larpconnect.njall.proto.ProtoDef;
 import com.larpconnect.njall.proto.WebfingerResponse;
 import io.vertx.core.Promise;
 import jakarta.inject.Inject;
@@ -20,7 +22,7 @@ final class WebfingerVerticle extends AbstractLcVerticle {
 
   @Override
   protected MessageResponse handleMessage(
-      byte[] spanId, MessageRequest message, Promise<Message> responsePromise) {
+      byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise) {
     String resource = null;
     var params = message.getParametersList();
 
@@ -32,13 +34,28 @@ final class WebfingerVerticle extends AbstractLcVerticle {
 
     if (resource == null) {
       // Return a basic empty response rather than fake data if it's missing or invalid
-      responsePromise.complete(WebfingerResponse.newBuilder().build());
+      WebfingerResponse wfResp = WebfingerResponse.newBuilder().build();
+      responsePromise.complete(
+          MessageReply.newBuilder()
+              .setProto(
+                  ProtoDef.newBuilder()
+                      .setProtobufName("WebfingerResponse")
+                      .setMessage(Any.pack(wfResp))
+                      .build())
+              .build());
       return BasicResponse.CONTINUE;
     }
 
     // Do not return made-up data. Just echo the subject without fake data.
     var response = WebfingerResponse.newBuilder().setSubject(resource).build();
-    responsePromise.complete(response);
+    responsePromise.complete(
+        MessageReply.newBuilder()
+            .setProto(
+                ProtoDef.newBuilder()
+                    .setProtobufName("WebfingerResponse")
+                    .setMessage(Any.pack(response))
+                    .build())
+            .build());
 
     return BasicResponse.CONTINUE;
   }

--- a/api/src/test/java/com/larpconnect/njall/api/verticle/AbstractLcVerticleTest.java
+++ b/api/src/test/java/com/larpconnect/njall/api/verticle/AbstractLcVerticleTest.java
@@ -2,9 +2,11 @@ package com.larpconnect.njall.api.verticle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.protobuf.Message;
+import com.google.protobuf.Any;
+import com.larpconnect.njall.proto.MessageReply;
 import com.larpconnect.njall.proto.MessageRequest;
 import com.larpconnect.njall.proto.Observability;
+import com.larpconnect.njall.proto.ProtoDef;
 import com.larpconnect.njall.proto.WebfingerResponse;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -66,7 +68,7 @@ final class AbstractLcVerticleTest {
             CHANNEL, mockRandom, () -> UUID.fromString("12345678-1234-1234-1234-123456789abc")) {
           @Override
           protected MessageResponse handleMessage(
-              byte[] spanId, MessageRequest message, Promise<Message> responsePromise) {
+              byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise) {
             handled.set(true);
             mdcTraceId.set(MDC.get("trace_id"));
             mdcParentSpanId.set(MDC.get("parent_span_id"));
@@ -135,7 +137,7 @@ final class AbstractLcVerticleTest {
             CHANNEL, mockRandom, () -> UUID.fromString("12345678-1234-1234-1234-123456789abc")) {
           @Override
           protected MessageResponse handleMessage(
-              byte[] spanId, MessageRequest message, Promise<Message> responsePromise) {
+              byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise) {
             handled.set(true);
             throw new IllegalStateException("Test exception");
           }
@@ -193,7 +195,7 @@ final class AbstractLcVerticleTest {
             CHANNEL, mockRandom, () -> UUID.fromString("12345678-1234-1234-1234-123456789abc")) {
           @Override
           protected MessageResponse handleMessage(
-              byte[] spanId, MessageRequest message, Promise<Message> responsePromise) {
+              byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise) {
             handled.set(true);
             responsePromise.fail(new IllegalStateException("Failed promise"));
             return BasicResponse.CONTINUE;
@@ -253,7 +255,7 @@ final class AbstractLcVerticleTest {
             CHANNEL, mockRandom, () -> UUID.fromString("12345678-1234-1234-1234-123456789abc")) {
           @Override
           protected MessageResponse handleMessage(
-              byte[] spanId, MessageRequest message, Promise<Message> responsePromise) {
+              byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise) {
             handled.set(true);
             mdcTraceId.set(MDC.get("trace_id"));
             mdcParentSpanId.set(MDC.get("parent_span_id"));
@@ -318,7 +320,7 @@ final class AbstractLcVerticleTest {
             CHANNEL, mockRandom, () -> UUID.fromString("12345678-1234-1234-1234-123456789abc")) {
           @Override
           protected MessageResponse handleMessage(
-              byte[] spanId, MessageRequest message, Promise<Message> responsePromise) {
+              byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise) {
             handled.set(true);
             mdcTraceId.set(MDC.get("trace_id"));
             mdcParentSpanId.set(MDC.get("parent_span_id"));
@@ -385,7 +387,7 @@ final class AbstractLcVerticleTest {
             CHANNEL, mockRandom, () -> UUID.fromString("12345678-1234-1234-1234-123456789abc")) {
           @Override
           protected MessageResponse handleMessage(
-              byte[] spanId, MessageRequest message, Promise<Message> responsePromise) {
+              byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise) {
             handled.set(true);
             mdcTraceId.set(MDC.get("trace_id"));
             mdcParentSpanId.set(MDC.get("parent_span_id"));
@@ -446,10 +448,17 @@ final class AbstractLcVerticleTest {
             CHANNEL, mockRandom, () -> UUID.fromString("12345678-1234-1234-1234-123456789abc")) {
           @Override
           protected MessageResponse handleMessage(
-              byte[] spanId, MessageRequest message, Promise<Message> responsePromise) {
+              byte[] spanId, MessageRequest message, Promise<MessageReply> responsePromise) {
             handled.set(true);
             WebfingerResponse response = WebfingerResponse.newBuilder().setSubject("reply").build();
-            responsePromise.complete(response);
+            responsePromise.complete(
+                MessageReply.newBuilder()
+                    .setProto(
+                        ProtoDef.newBuilder()
+                            .setProtobufName("WebfingerResponse")
+                            .setMessage(Any.pack(response))
+                            .build())
+                    .build());
             return BasicResponse.CONTINUE;
           }
         };
@@ -470,8 +479,13 @@ final class AbstractLcVerticleTest {
                                 testContext.verify(
                                     () -> {
                                       assertThat(handled.get()).isTrue();
-                                      assertThat(reply.body())
-                                          .isInstanceOf(WebfingerResponse.class);
+                                      assertThat(reply.body()).isInstanceOf(MessageReply.class);
+                                      MessageReply mr = (MessageReply) reply.body();
+                                      assertThat(
+                                              mr.getProto()
+                                                  .getMessage()
+                                                  .is(WebfingerResponse.class))
+                                          .isTrue();
                                       testContext.completeNow();
                                     });
                               }));

--- a/api/src/test/java/com/larpconnect/njall/api/verticle/WebfingerVerticleTest.java
+++ b/api/src/test/java/com/larpconnect/njall/api/verticle/WebfingerVerticleTest.java
@@ -3,6 +3,7 @@ package com.larpconnect.njall.api.verticle;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.larpconnect.njall.common.id.IdGenerator;
+import com.larpconnect.njall.proto.MessageReply;
 import com.larpconnect.njall.proto.MessageRequest;
 import com.larpconnect.njall.proto.Parameter;
 import com.larpconnect.njall.proto.WebfingerResponse;
@@ -47,13 +48,15 @@ final class WebfingerVerticleTest {
 
     vertx
         .eventBus()
-        .<WebfingerResponse>request(WebfingerVerticle.CHANNEL, request)
+        .<MessageReply>request(WebfingerVerticle.CHANNEL, request)
         .onComplete(
             testContext.succeeding(
                 reply -> {
                   testContext.verify(
                       () -> {
-                        WebfingerResponse response = reply.body();
+                        MessageReply replyMsg = reply.body();
+                        WebfingerResponse response =
+                            replyMsg.getProto().getMessage().unpack(WebfingerResponse.class);
                         assertThat(response.getSubject()).isEqualTo("acct:alice@example.com");
                         testContext.completeNow();
                       });
@@ -66,13 +69,15 @@ final class WebfingerVerticleTest {
 
     vertx
         .eventBus()
-        .<WebfingerResponse>request(WebfingerVerticle.CHANNEL, request)
+        .<MessageReply>request(WebfingerVerticle.CHANNEL, request)
         .onComplete(
             testContext.succeeding(
                 reply -> {
                   testContext.verify(
                       () -> {
-                        WebfingerResponse response = reply.body();
+                        MessageReply replyMsg = reply.body();
+                        WebfingerResponse response =
+                            replyMsg.getProto().getMessage().unpack(WebfingerResponse.class);
                         assertThat(response.getSubject()).isEmpty();
                         testContext.completeNow();
                       });

--- a/proto/src/main/proto/message.proto
+++ b/proto/src/main/proto/message.proto
@@ -59,3 +59,15 @@ message MessageRequest {
   }
 }
 
+
+message MessageReply {
+  Observability traceparent = 1;
+  Authentication authentication = 4;
+  Header header = 5;
+  repeated Parameter parameters = 6;
+
+  oneof payload {
+    ProtoDef proto = 2;
+    MimeType mime = 3;
+  }
+}


### PR DESCRIPTION
Updated AbstractLcVerticle to return a custom MessageReply protobuf object instead of a generic Message to mirror MessageRequest. Updated WebfingerVerticle and related tests to support the new response envelope.

---
*PR created automatically by Jules for task [16413430847095383748](https://jules.google.com/task/16413430847095383748) started by @dclements*