### PR TITLE
📄 Nihiluxinator: Fix incorrect skill paths in SKILLS.md

### DIFF
--- a/.agents/SKILLS.md
+++ b/.agents/SKILLS.md
@@ -27,14 +27,14 @@ If working with Render, load Render's documentation from context7.
 
 ## 3. Domain-Specific Skills (Contextual)
 
-| Skill Name                   | Activation Trigger                                                                                    | Source File                   |
-|:-----------------------------|:------------------------------------------------------------------------------------------------------|:------------------------------|
-| **Guice Dependency**         | Modifications to `*Module.java`                                                                       | `.agents/skills/guice_di.md`  |
-| **Gradle Mastery**           | Modification of any kotlin (`*.kts`, `*.kt`), build, or setting file                                  | `.agents/skills/build.md`     |
-| **Vert.x Mastery**           | Modification of a `*Verticle.java` file, interacting with a `vertx` object, modification of `:server` | `.agents/skills/vertx.md`     |
-| **Data Handling**            | Any modifications to JSON or CSV files or work inside of `:proto`                                     | `.jules/skills/data.md`       |
-| **Markdown Documentation**   | Building documentation in markdown (`.md`)                                                            | `.jules/skills/markdown.md`   |
-| **Breakglass Documentation** | If you are "stuck" on a problem                                                                       | `.jules/skills/breakglass.md` |
+| Skill Name                   | Activation Trigger                                                                                    | Source File                    |
+|:-----------------------------|:------------------------------------------------------------------------------------------------------|:-------------------------------|
+| **Guice Dependency**         | Modifications to `*Module.java`                                                                       | `.agents/skills/guice_di.md`   |
+| **Gradle Mastery**           | Modification of any kotlin (`*.kts`, `*.kt`), build, or setting file                                  | `.agents/skills/build.md`      |
+| **Vert.x Mastery**           | Modification of a `*Verticle.java` file, interacting with a `vertx` object, modification of `:server` | `.agents/skills/vertx.md`      |
+| **Data Handling**            | Any modifications to JSON or CSV files or work inside of `:proto`                                     | `.agents/skills/data.md`       |
+| **Markdown Documentation**   | Building documentation in markdown (`.md`)                                                            | `.agents/skills/markdown.md`   |
+| **Breakglass Documentation** | If you are "stuck" on a problem                                                                       | `.agents/skills/breakglass.md` |
 
 ## 3. Delegation Protocol
 


### PR DESCRIPTION
💡 What was changed
Corrected file paths within `.agents/SKILLS.md` for Domain-Specific Skills (`data.md`, `markdown.md`, and `breakglass.md`).

Consistency edits that were needed.
These paths previously referenced a non-existent `.jules/` directory instead of `.agents/`.

🎯 Why the documentation is helpful
This ensures that the skills registry correctly points to existing contextual guidelines, preventing AI agents (including Jules) from encountering file-not-found issues when dynamically loading their skill definitions.

---
*PR created automatically by Jules for task [4647870744734792803](https://jules.google.com/task/4647870744734792803) started by @dclements*