### PR TITLE
🪳 Nifftyinator: CLEAN! IT! UP!

### DIFF
--- a/server/src/main/java/com/larpconnect/njall/server/Main.java
+++ b/server/src/main/java/com/larpconnect/njall/server/Main.java
@@ -60,7 +60,7 @@ final class Main {
     } catch (RuntimeException e) {
       logger.error("Failed to start server", e);
       System.exit(1);
-      return null;
+      throw new AssertionError("Unreachable");
     }
     return lifecycle;
   }


### PR DESCRIPTION
💡 What was changed
Replaced `return null;` with `throw new AssertionError("Unreachable");` in `Main.java` following `System.exit(1);`.

Consistency edits that were needed
This change satisfies the `@ReturnValuesAreNonnullByDefault` compiler check correctly, as returning `null` after terminating the JVM was violating nullability rules but going undetected. Throwing an error ensures compliance.

---
*PR created automatically by Jules for task [7660488497700619440](https://jules.google.com/task/7660488497700619440) started by @dclements*