### PR TITLE
chore: remove Singleton scope from verticles

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/verticle/ApiVerticleModule.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/ApiVerticleModule.java
@@ -1,7 +1,6 @@
 package com.larpconnect.njall.api.verticle;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.vertx.core.Verticle;
 
@@ -14,9 +13,6 @@ public final class ApiVerticleModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(WebfingerVerticle.class).in(Scopes.SINGLETON);
-    bind(NodeinfoWellKnownVerticle.class).in(Scopes.SINGLETON);
-    bind(NodeinfoVerticle.class).in(Scopes.SINGLETON);
     Multibinder<Verticle> verticleBinder = Multibinder.newSetBinder(binder(), Verticle.class);
     verticleBinder.addBinding().to(WebfingerVerticle.class);
     verticleBinder.addBinding().to(NodeinfoWellKnownVerticle.class);

--- a/server/src/main/java/com/larpconnect/njall/server/ServerBindingModule.java
+++ b/server/src/main/java/com/larpconnect/njall/server/ServerBindingModule.java
@@ -2,7 +2,6 @@ package com.larpconnect.njall.server;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.larpconnect.njall.common.annotations.InstallInstead;
@@ -32,7 +31,7 @@ final class ServerBindingModule extends AbstractModule {
   protected void configure() {
     bind(new TypeLiteral<Optional<Consumer<Integer>>>() {}).toInstance(Optional.empty());
 
-    bind(MainVerticle.class).to(DefaultMainVerticle.class).in(Scopes.SINGLETON);
+    bind(MainVerticle.class).to(DefaultMainVerticle.class);
     var verticles = Multibinder.newSetBinder(binder(), Verticle.class);
     verticles.addBinding().to(WebServerVerticle.class);
   }

--- a/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
+++ b/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
@@ -18,7 +18,6 @@ import io.vertx.ext.web.healthchecks.HealthCheckHandler;
 import io.vertx.ext.web.openapi.router.RouterBuilder;
 import io.vertx.openapi.contract.OpenAPIContract;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -30,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Web server verticle that serves OpenAPI specification. */
-@Singleton
 @BuildWith(ServerModule.class)
 final class WebServerVerticle extends AbstractVerticle {
   private static final int DEFAULT_PORT = 8080;


### PR DESCRIPTION
Verticles can be restarted, created again, or have multiple copies, so they should not be bound to the Singleton scope. This PR removes the `@Singleton` annotation from `WebServerVerticle` and the explicit `.in(Scopes.SINGLETON)` bindings in `ServerBindingModule` and `ApiVerticleModule`.

---
*PR created automatically by Jules for task [11646186737093508996](https://jules.google.com/task/11646186737093508996) started by @dclements*