### PR TITLE
📄 Nihiluxinator: Add Javadocs to ApiObjectParser

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/ApiObjectParser.java
+++ b/api/src/main/java/com/larpconnect/njall/api/ApiObjectParser.java
@@ -18,9 +18,31 @@ import io.vertx.core.json.JsonObject;
 @DefaultImplementation(DefaultApiObjectParser.class)
 public interface ApiObjectParser {
 
-  /** Converts an ApiObject to a Vert.x JsonObject, lifting extensions to the top level. */
+  /**
+   * Converts a structured {@link ApiObject} into a flattened {@link JsonObject}.
+   *
+   * <p>In the internal Protobuf definition, domain-specific fields are nested inside the {@code
+   * extensions} map to maintain type safety. This method flattens those nested structures into the
+   * root JSON level to match the external API specification expected by clients. For example, a
+   * Document's media type and content will appear as top-level JSON fields.
+   *
+   * @param obj the internal type-safe representation
+   * @return the flattened JSON representation suitable for HTTP responses
+   * @throws IllegalStateException if the underlying Protobuf conversion fails
+   */
   JsonObject toJson(ApiObject obj);
 
-  /** Converts a Vert.x JsonObject back to an ApiObject. */
+  /**
+   * Reconstructs an {@link ApiObject} from a flattened incoming {@link JsonObject}.
+   *
+   * <p>This process reverses {@link #toJson(ApiObject)} by examining the {@code type} array field
+   * in the JSON payload (e.g., "Document", "Event") and routing the flat fields into the
+   * appropriate strongly-typed Protobuf extension message. It also handles special cases, such as
+   * embedding raw text content into the {@code Document} extension.
+   *
+   * @param json the flattened JSON payload from an HTTP request
+   * @return the reconstructed type-safe internal representation
+   * @throws IllegalArgumentException if the JSON structure is malformed or conversion fails
+   */
   ApiObject fromJson(JsonObject json);
 }


### PR DESCRIPTION
💡 What was changed
Updated the Javadocs for the `toJson` and `fromJson` methods in `ApiObjectParser.java` to provide comprehensive explanations. The new documentation details how internal type-safe Protobuf extensions are flattened into root-level JSON structures for external API compliance, and how that process is reversed when parsing incoming JSON.

Consistency edits that were needed.
The existing one-line comments were expanded into detailed paragraphs following the project's formatting constraints, ensuring lines do not exceed the 100-character limit and the text focuses on architectural reasoning.

🎯 Why the documentation is helpful
It clearly explains the "why" behind the impedance mismatch between the internal schema (Protobuf) and the external schema-less format (JSON), helping both developers and AIs understand the critical role this parser plays in the system's architecture.

---
*PR created automatically by Jules for task [12845368489839560986](https://jules.google.com/task/12845368489839560986) started by @dclements*