### PR TITLE
📄 Nihiluxinator: Add missing Javadocs to server DI qualifiers

### DIFF
--- a/server/src/main/java/com/larpconnect/njall/server/annotations/OpenApiSpec.java
+++ b/server/src/main/java/com/larpconnect/njall/server/annotations/OpenApiSpec.java
@@ -9,6 +9,14 @@ import jakarta.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+/**
+ * Guice qualifier annotation used to identify the path or filename of the OpenAPI specification.
+ *
+ * <p>By using a dedicated qualifier rather than binding to a generic string or using named
+ * bindings, the injection of the OpenAPI specification configuration value becomes type-safe and
+ * robust against spelling errors. It ensures that the Vert.x web server initializes its routes
+ * using the correct contract definition.
+ */
 @Qualifier
 @Retention(RUNTIME)
 @Target({FIELD, PARAMETER, METHOD})

--- a/server/src/main/java/com/larpconnect/njall/server/annotations/WebPort.java
+++ b/server/src/main/java/com/larpconnect/njall/server/annotations/WebPort.java
@@ -9,6 +9,14 @@ import jakarta.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+/**
+ * Guice qualifier annotation used to identify the listening port for the main web server verticle.
+ *
+ * <p>Using a strongly-typed qualifier avoids the ambiguity of injecting generic integers. This
+ * enforces that the server port configuration value, whether derived from environment variables or
+ * JSON configuration, is deterministically provided to the component responsible for binding the
+ * HTTP server, decoupling configuration parsing from the Verticle implementation.
+ */
 @Qualifier
 @Retention(RUNTIME)
 @Target({FIELD, PARAMETER, METHOD})


### PR DESCRIPTION
💡 What was changed
Added missing class-level Javadocs to the `WebPort` and `OpenApiSpec` annotations in the `:server` module.

Consistency edits that were needed.
None.

🎯 Why the documentation is helpful
These annotations are public elements of the API used for Guice dependency injection. The new documentation explains *why* these qualifiers exist—specifically, how they provide type safety over generic bindings (like strings or integers), prevent spelling errors, and help decouple configuration parsing from Verticle implementation. This fulfills the guideline that publicly accessible types require comprehensive Javadoc documentation explaining the *why* of architectural decisions.

---
*PR created automatically by Jules for task [9264711341495402708](https://jules.google.com/task/9264711341495402708) started by @dclements*