### PR TITLE
🚧 Pentiousinator: Centralize test engines

### DIFF
--- a/buildSrc/src/main/kotlin/larpconnect.testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.testing.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     if (project.name != "test") {
         testImplementation(project(":test"))
     }
+    testRuntimeOnly(libs.junit.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
     testRuntimeOnly(libs.logback.classic)
 }
 

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -14,7 +14,4 @@ dependencies {
     api(libs.mockito.junit.jupiter)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
-
-    runtimeOnly(libs.junit.engine)
-    runtimeOnly(libs.junit.platform.launcher)
 }


### PR DESCRIPTION
💡 What was changed:
Moved `libs.junit.engine` and `libs.junit.platform.launcher` out of the `:test` module's `build.gradle.kts` and centralized them as `testRuntimeOnly` dependencies within the shared testing convention plugin (`larpconnect.testing.gradle.kts`).

🎯 Why it helps make the build system better:
The `:test` module is a shared test utility/library module that other modules inherit as a `testImplementation` dependency. Previously, test engine dependencies were declared as `runtimeOnly` in `:test`, which unintentionally exposed them as `testRuntimeOnly` to consumers depending on `:test`. Moving these to the shared `larpconnect.testing` convention plugin applies them explicitly as `testRuntimeOnly` to any module configured for testing, which creates a cleaner, more correct dependency hierarchy and prevents `:test` from unnecessarily leaking runtime test engine dependencies.

---
*PR created automatically by Jules for task [12256744218031251169](https://jules.google.com/task/12256744218031251169) started by @dclements*