### PR TITLE
Feature: DAO schema selection

### DIFF
--- a/data/src/main/java/com/larpconnect/njall/data/dao/AbstractDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/AbstractDao.java
@@ -3,14 +3,9 @@ package com.larpconnect.njall.data.dao;
 import com.larpconnect.njall.data.entity.DatabaseObject;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Provider;
+import javax.annotation.Nullable;
 import org.hibernate.reactive.mutiny.Mutiny;
 
-/**
- * Base implementation of the Dao interface.
- *
- * @param <T> The entity type
- * @param <ID> The type of the identifier
- */
 abstract class AbstractDao<T extends DatabaseObject, ID> implements Dao<T, ID> {
 
   private final Provider<Mutiny.SessionFactory> sessionFactoryProvider;
@@ -27,13 +22,17 @@ abstract class AbstractDao<T extends DatabaseObject, ID> implements Dao<T, ID> {
   }
 
   @Override
-  public Uni<T> findById(String serverId, ID id) {
-    return getSessionFactory().withSession(serverId, session -> session.find(entityClass, id));
+  public Uni<T> findById(@Nullable String serverId, ID id) {
+    return getSessionFactory()
+        .withSession(
+            TenantContext.formatTenantId(serverId), session -> session.find(entityClass, id));
   }
 
   @Override
-  public Uni<Void> persist(String serverId, T entity) {
+  public Uni<Void> persist(@Nullable String serverId, T entity) {
     return getSessionFactory()
-        .withSession(serverId, session -> session.persist(entity).call(session::flush));
+        .withSession(
+            TenantContext.formatTenantId(serverId),
+            session -> session.persist(entity).call(session::flush));
   }
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/AbstractDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/AbstractDao.java
@@ -27,12 +27,13 @@ abstract class AbstractDao<T extends DatabaseObject, ID> implements Dao<T, ID> {
   }
 
   @Override
-  public Uni<T> findById(ID id) {
-    return getSessionFactory().withSession(session -> session.find(entityClass, id));
+  public Uni<T> findById(String serverId, ID id) {
+    return getSessionFactory().withSession(serverId, session -> session.find(entityClass, id));
   }
 
   @Override
-  public Uni<Void> persist(T entity) {
-    return getSessionFactory().withSession(session -> session.persist(entity).call(session::flush));
+  public Uni<Void> persist(String serverId, T entity) {
+    return getSessionFactory()
+        .withSession(serverId, session -> session.persist(entity).call(session::flush));
   }
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/ActorEndpointDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/ActorEndpointDao.java
@@ -3,12 +3,13 @@ package com.larpconnect.njall.data.dao;
 import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import com.larpconnect.njall.data.entity.ActorEndpoint;
 import io.smallrye.mutiny.Uni;
+import javax.annotation.Nullable;
 
 /** DAO for ActorEndpoint. */
 @DefaultImplementation(DefaultActorEndpointDao.class)
 public interface ActorEndpointDao {
 
-  Uni<ActorEndpoint> findById(String serverId, ActorEndpoint.ActorEndpointId id);
+  Uni<ActorEndpoint> findById(@Nullable String serverId, ActorEndpoint.ActorEndpointId id);
 
-  Uni<Void> persist(String serverId, ActorEndpoint entity);
+  Uni<Void> persist(@Nullable String serverId, ActorEndpoint entity);
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/ActorEndpointDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/ActorEndpointDao.java
@@ -8,7 +8,7 @@ import io.smallrye.mutiny.Uni;
 @DefaultImplementation(DefaultActorEndpointDao.class)
 public interface ActorEndpointDao {
 
-  Uni<ActorEndpoint> findById(ActorEndpoint.ActorEndpointId id);
+  Uni<ActorEndpoint> findById(String serverId, ActorEndpoint.ActorEndpointId id);
 
-  Uni<Void> persist(ActorEndpoint entity);
+  Uni<Void> persist(String serverId, ActorEndpoint entity);
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
@@ -17,7 +17,7 @@ public interface Dao<T extends DatabaseObject, ID> {
    * @param id The identifier
    * @return A Uni containing the entity, or null if not found
    */
-  Uni<T> findById(ID id);
+  Uni<T> findById(String serverId, ID id);
 
   /**
    * Persists the given entity to the database.
@@ -25,5 +25,5 @@ public interface Dao<T extends DatabaseObject, ID> {
    * @param entity The entity to persist
    * @return A Uni representing the completion of the persistence operation
    */
-  Uni<Void> persist(T entity);
+  Uni<Void> persist(String serverId, T entity);
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import com.larpconnect.njall.data.entity.DatabaseObject;
 import io.smallrye.mutiny.Uni;
+import javax.annotation.Nullable;
 
 /**
  * Base Data Access Object interface for all database entities.
@@ -14,16 +15,18 @@ public interface Dao<T extends DatabaseObject, ID> {
   /**
    * Finds an entity by its identifier.
    *
+   * @param serverId The specific server id/tenant id (can be null for base/public interactions).
    * @param id The identifier
    * @return A Uni containing the entity, or null if not found
    */
-  Uni<T> findById(String serverId, ID id);
+  Uni<T> findById(@Nullable String serverId, ID id);
 
   /**
    * Persists the given entity to the database.
    *
+   * @param serverId The specific server id/tenant id (can be null for base/public interactions).
    * @param entity The entity to persist
    * @return A Uni representing the completion of the persistence operation
    */
-  Uni<Void> persist(String serverId, T entity);
+  Uni<Void> persist(@Nullable String serverId, T entity);
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/DefaultActorEndpointDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/DefaultActorEndpointDao.java
@@ -18,16 +18,16 @@ final class DefaultActorEndpointDao implements ActorEndpointDao {
   }
 
   @Override
-  public Uni<ActorEndpoint> findById(ActorEndpoint.ActorEndpointId id) {
+  public Uni<ActorEndpoint> findById(String serverId, ActorEndpoint.ActorEndpointId id) {
     return sessionFactoryProvider
         .get()
-        .withSession(session -> session.find(ActorEndpoint.class, id));
+        .withSession(serverId, session -> session.find(ActorEndpoint.class, id));
   }
 
   @Override
-  public Uni<Void> persist(ActorEndpoint entity) {
+  public Uni<Void> persist(String serverId, ActorEndpoint entity) {
     return sessionFactoryProvider
         .get()
-        .withSession(session -> session.persist(entity).call(session::flush));
+        .withSession(serverId, session -> session.persist(entity).call(session::flush));
   }
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/DefaultActorEndpointDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/DefaultActorEndpointDao.java
@@ -5,6 +5,7 @@ import com.larpconnect.njall.data.entity.ActorEndpoint;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
+import javax.annotation.Nullable;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 @BuildWith(DaoModule.class)
@@ -18,16 +19,20 @@ final class DefaultActorEndpointDao implements ActorEndpointDao {
   }
 
   @Override
-  public Uni<ActorEndpoint> findById(String serverId, ActorEndpoint.ActorEndpointId id) {
+  public Uni<ActorEndpoint> findById(@Nullable String serverId, ActorEndpoint.ActorEndpointId id) {
     return sessionFactoryProvider
         .get()
-        .withSession(serverId, session -> session.find(ActorEndpoint.class, id));
+        .withSession(
+            TenantContext.formatTenantId(serverId),
+            session -> session.find(ActorEndpoint.class, id));
   }
 
   @Override
-  public Uni<Void> persist(String serverId, ActorEndpoint entity) {
+  public Uni<Void> persist(@Nullable String serverId, ActorEndpoint entity) {
     return sessionFactoryProvider
         .get()
-        .withSession(serverId, session -> session.persist(entity).call(session::flush));
+        .withSession(
+            TenantContext.formatTenantId(serverId),
+            session -> session.persist(entity).call(session::flush));
   }
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/DefaultStudioRoleDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/DefaultStudioRoleDao.java
@@ -5,6 +5,7 @@ import com.larpconnect.njall.data.entity.StudioRole;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
+import javax.annotation.Nullable;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 @BuildWith(DaoModule.class)
@@ -17,16 +18,19 @@ final class DefaultStudioRoleDao implements StudioRoleDao {
   }
 
   @Override
-  public Uni<StudioRole> findById(String serverId, StudioRole.StudioRoleId id) {
+  public Uni<StudioRole> findById(@Nullable String serverId, StudioRole.StudioRoleId id) {
     return sessionFactoryProvider
         .get()
-        .withSession(serverId, session -> session.find(StudioRole.class, id));
+        .withSession(
+            TenantContext.formatTenantId(serverId), session -> session.find(StudioRole.class, id));
   }
 
   @Override
-  public Uni<Void> persist(String serverId, StudioRole entity) {
+  public Uni<Void> persist(@Nullable String serverId, StudioRole entity) {
     return sessionFactoryProvider
         .get()
-        .withSession(serverId, session -> session.persist(entity).call(session::flush));
+        .withSession(
+            TenantContext.formatTenantId(serverId),
+            session -> session.persist(entity).call(session::flush));
   }
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/DefaultStudioRoleDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/DefaultStudioRoleDao.java
@@ -17,14 +17,16 @@ final class DefaultStudioRoleDao implements StudioRoleDao {
   }
 
   @Override
-  public Uni<StudioRole> findById(StudioRole.StudioRoleId id) {
-    return sessionFactoryProvider.get().withSession(session -> session.find(StudioRole.class, id));
+  public Uni<StudioRole> findById(String serverId, StudioRole.StudioRoleId id) {
+    return sessionFactoryProvider
+        .get()
+        .withSession(serverId, session -> session.find(StudioRole.class, id));
   }
 
   @Override
-  public Uni<Void> persist(StudioRole entity) {
+  public Uni<Void> persist(String serverId, StudioRole entity) {
     return sessionFactoryProvider
         .get()
-        .withSession(session -> session.persist(entity).call(session::flush));
+        .withSession(serverId, session -> session.persist(entity).call(session::flush));
   }
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProvider.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProvider.java
@@ -1,19 +1,41 @@
 package com.larpconnect.njall.data.dao;
 
 import io.vertx.sqlclient.Pool;
+import java.util.concurrent.CompletionStage;
+import java.util.regex.Pattern;
+import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPool;
 
 final class SchemaSelectionConnectionProvider extends DefaultSqlClientPool {
 
   private static final long serialVersionUID = 1L;
+  private static final Pattern VALID_TENANT_PATTERN = Pattern.compile("^[a-z0-9]+$");
 
   SchemaSelectionConnectionProvider() {}
 
   @Override
   public Pool getTenantPool(String tenantId) {
-    if (tenantId == null || tenantId.isEmpty() || tenantId.equals("public")) {
-      return getPool();
+    if (tenantId == null || tenantId.isEmpty()) {
+      throw new IllegalArgumentException("Tenant ID cannot be null or empty");
+    }
+    if (!VALID_TENANT_PATTERN.matcher(tenantId).matches()) {
+      throw new IllegalArgumentException("Invalid tenant ID: " + tenantId);
     }
     return getPool();
+  }
+
+  @Override
+  public CompletionStage<ReactiveConnection> getConnection(String tenantId) {
+    if (tenantId == null || tenantId.isEmpty()) {
+      throw new IllegalArgumentException("Tenant ID cannot be null or empty");
+    }
+    if (!VALID_TENANT_PATTERN.matcher(tenantId).matches()) {
+      throw new IllegalArgumentException("Invalid tenant ID: " + tenantId);
+    }
+
+    return super.getConnection(tenantId)
+        .thenCompose(
+            connection ->
+                connection.execute("SET search_path TO " + tenantId).thenApply(v -> connection));
   }
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProvider.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProvider.java
@@ -1,0 +1,19 @@
+package com.larpconnect.njall.data.dao;
+
+import io.vertx.sqlclient.Pool;
+import org.hibernate.reactive.pool.impl.DefaultSqlClientPool;
+
+final class SchemaSelectionConnectionProvider extends DefaultSqlClientPool {
+
+  private static final long serialVersionUID = 1L;
+
+  SchemaSelectionConnectionProvider() {}
+
+  @Override
+  public Pool getTenantPool(String tenantId) {
+    if (tenantId == null || tenantId.isEmpty() || tenantId.equals("public")) {
+      return getPool();
+    }
+    return getPool();
+  }
+}

--- a/data/src/main/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProvider.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProvider.java
@@ -9,33 +9,38 @@ import org.hibernate.reactive.pool.impl.DefaultSqlClientPool;
 final class SchemaSelectionConnectionProvider extends DefaultSqlClientPool {
 
   private static final long serialVersionUID = 1L;
-  private static final Pattern VALID_TENANT_PATTERN = Pattern.compile("^[a-z0-9]+$");
+  private static final Pattern VALID_SERVER_TENANT_PATTERN =
+      Pattern.compile("^njall_server_([a-z]+[a-z0-9]+){3,32}$");
 
   SchemaSelectionConnectionProvider() {}
 
   @Override
   public Pool getTenantPool(String tenantId) {
-    if (tenantId == null || tenantId.isEmpty()) {
-      throw new IllegalArgumentException("Tenant ID cannot be null or empty");
-    }
-    if (!VALID_TENANT_PATTERN.matcher(tenantId).matches()) {
-      throw new IllegalArgumentException("Invalid tenant ID: " + tenantId);
-    }
-    return getPool();
+    validateTenantId(tenantId);
+    return super.getTenantPool(tenantId);
   }
 
   @Override
   public CompletionStage<ReactiveConnection> getConnection(String tenantId) {
-    if (tenantId == null || tenantId.isEmpty()) {
-      throw new IllegalArgumentException("Tenant ID cannot be null or empty");
-    }
-    if (!VALID_TENANT_PATTERN.matcher(tenantId).matches()) {
-      throw new IllegalArgumentException("Invalid tenant ID: " + tenantId);
-    }
+    validateTenantId(tenantId);
 
-    return super.getConnection(tenantId)
+    return super.getConnection()
         .thenCompose(
             connection ->
                 connection.execute("SET search_path TO " + tenantId).thenApply(v -> connection));
+  }
+
+  private void validateTenantId(String tenantId) {
+    if (tenantId == null || tenantId.isEmpty()) {
+      throw new IllegalArgumentException("Tenant ID cannot be null or empty");
+    }
+    if (tenantId.equals("njall_base")
+        || tenantId.equals("njall_admin")
+        || tenantId.equals("njall_analytics")) {
+      return;
+    }
+    if (!VALID_SERVER_TENANT_PATTERN.matcher(tenantId).matches()) {
+      throw new IllegalArgumentException("Invalid tenant ID: " + tenantId);
+    }
   }
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/StudioRoleDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/StudioRoleDao.java
@@ -7,7 +7,7 @@ import io.smallrye.mutiny.Uni;
 /** DAO for StudioRole. */
 @DefaultImplementation(DefaultStudioRoleDao.class)
 public interface StudioRoleDao {
-  Uni<StudioRole> findById(StudioRole.StudioRoleId id);
+  Uni<StudioRole> findById(String serverId, StudioRole.StudioRoleId id);
 
-  Uni<Void> persist(StudioRole entity);
+  Uni<Void> persist(String serverId, StudioRole entity);
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/StudioRoleDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/StudioRoleDao.java
@@ -3,11 +3,12 @@ package com.larpconnect.njall.data.dao;
 import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import com.larpconnect.njall.data.entity.StudioRole;
 import io.smallrye.mutiny.Uni;
+import javax.annotation.Nullable;
 
 /** DAO for StudioRole. */
 @DefaultImplementation(DefaultStudioRoleDao.class)
 public interface StudioRoleDao {
-  Uni<StudioRole> findById(String serverId, StudioRole.StudioRoleId id);
+  Uni<StudioRole> findById(@Nullable String serverId, StudioRole.StudioRoleId id);
 
-  Uni<Void> persist(String serverId, StudioRole entity);
+  Uni<Void> persist(@Nullable String serverId, StudioRole entity);
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/TenantContext.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/TenantContext.java
@@ -1,0 +1,49 @@
+package com.larpconnect.njall.data.dao;
+
+import io.vertx.core.Vertx;
+import javax.annotation.Nullable;
+
+final class TenantContext {
+
+  private static final String TENANT_KEY = "CURRENT_TENANT";
+
+  private TenantContext() {}
+
+  @Nullable
+  public static String getCurrentTenant() {
+    var context = Vertx.currentContext();
+    if (context != null) {
+      return (String) context.get(TENANT_KEY);
+    }
+    return null;
+  }
+
+  public static void setCurrentTenant(String tenantId) {
+    var context = Vertx.currentContext();
+    if (context != null) {
+      context.put(TENANT_KEY, formatTenantId(tenantId));
+    }
+  }
+
+  public static void clear() {
+    var context = Vertx.currentContext();
+    if (context != null) {
+      context.remove(TENANT_KEY);
+    }
+  }
+
+  static String formatTenantId(@Nullable String serverId) {
+    if (serverId == null || serverId.isEmpty()) {
+      return "njall_base";
+    }
+    if (serverId.equals("njall_base")
+        || serverId.equals("njall_admin")
+        || serverId.equals("njall_analytics")) {
+      return serverId;
+    }
+    if (serverId.startsWith("njall_server_")) {
+      return serverId;
+    }
+    return "njall_server_" + serverId;
+  }
+}

--- a/data/src/main/java/com/larpconnect/njall/data/dao/TenantResolver.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/TenantResolver.java
@@ -1,0 +1,18 @@
+package com.larpconnect.njall.data.dao;
+
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+
+final class TenantResolver implements CurrentTenantIdentifierResolver<String> {
+
+  TenantResolver() {}
+
+  @Override
+  public String resolveCurrentTenantIdentifier() {
+    return "public";
+  }
+
+  @Override
+  public boolean validateExistingCurrentSessions() {
+    return false;
+  }
+}

--- a/data/src/main/java/com/larpconnect/njall/data/dao/TenantResolver.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/TenantResolver.java
@@ -8,7 +8,8 @@ final class TenantResolver implements CurrentTenantIdentifierResolver<String> {
 
   @Override
   public String resolveCurrentTenantIdentifier() {
-    return "njall";
+    String currentTenant = TenantContext.getCurrentTenant();
+    return currentTenant == null ? "njall_base" : currentTenant;
   }
 
   @Override

--- a/data/src/main/java/com/larpconnect/njall/data/dao/TenantResolver.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/TenantResolver.java
@@ -8,7 +8,7 @@ final class TenantResolver implements CurrentTenantIdentifierResolver<String> {
 
   @Override
   public String resolveCurrentTenantIdentifier() {
-    return "public";
+    return "njall";
   }
 
   @Override

--- a/data/src/main/resources/META-INF/persistence.xml
+++ b/data/src/main/resources/META-INF/persistence.xml
@@ -34,6 +34,8 @@
             <property name="jakarta.persistence.jdbc.password" value="test"/>
 
             <property name="hibernate.hbm2ddl.auto" value="none"/>
+            <property name="hibernate.tenant_identifier_resolver" value="com.larpconnect.njall.data.dao.TenantResolver"/>
+            <property name="hibernate.multi_tenant_connection_provider" value="com.larpconnect.njall.data.dao.SchemaSelectionConnectionProvider"/>
         </properties>
 
     </persistence-unit>

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ActorDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ActorDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class ActorDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class ActorDaoTest {
 
     when(sessionMock.find(Actor.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Actor.class, id);
@@ -60,6 +61,6 @@ final class ActorDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ActorDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ActorDaoTest.java
@@ -49,7 +49,7 @@ final class ActorDaoTest {
 
     when(sessionMock.find(Actor.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Actor.class, id);
@@ -61,6 +61,6 @@ final class ActorDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ActorEndpointDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ActorEndpointDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,10 +33,10 @@ final class ActorEndpointDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -50,7 +51,7 @@ final class ActorEndpointDaoTest {
     when(sessionMock.find(ActorEndpoint.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(ActorEndpoint.class, id);
@@ -62,6 +63,6 @@ final class ActorEndpointDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ActorEndpointDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ActorEndpointDaoTest.java
@@ -51,7 +51,7 @@ final class ActorEndpointDaoTest {
     when(sessionMock.find(ActorEndpoint.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(ActorEndpoint.class, id);
@@ -63,6 +63,6 @@ final class ActorEndpointDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CampaignDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CampaignDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class CampaignDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class CampaignDaoTest {
 
     when(sessionMock.find(Campaign.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Campaign.class, id);
@@ -60,6 +61,6 @@ final class CampaignDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CampaignDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CampaignDaoTest.java
@@ -49,7 +49,7 @@ final class CampaignDaoTest {
 
     when(sessionMock.find(Campaign.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Campaign.class, id);
@@ -61,6 +61,6 @@ final class CampaignDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CharacterDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CharacterDaoTest.java
@@ -49,7 +49,7 @@ final class CharacterDaoTest {
 
     when(sessionMock.find(Character.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Character.class, id);
@@ -61,6 +61,6 @@ final class CharacterDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CharacterDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CharacterDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class CharacterDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class CharacterDaoTest {
 
     when(sessionMock.find(Character.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Character.class, id);
@@ -60,6 +61,6 @@ final class CharacterDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CharacterInstanceDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CharacterInstanceDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class CharacterInstanceDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -49,7 +50,7 @@ final class CharacterInstanceDaoTest {
     when(sessionMock.find(CharacterInstance.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(CharacterInstance.class, id);
@@ -61,6 +62,6 @@ final class CharacterInstanceDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CharacterInstanceDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CharacterInstanceDaoTest.java
@@ -50,7 +50,7 @@ final class CharacterInstanceDaoTest {
     when(sessionMock.find(CharacterInstance.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(CharacterInstance.class, id);
@@ -62,6 +62,6 @@ final class CharacterInstanceDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CollectionDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CollectionDaoTest.java
@@ -49,7 +49,7 @@ final class CollectionDaoTest {
 
     when(sessionMock.find(Collection.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Collection.class, id);
@@ -61,6 +61,6 @@ final class CollectionDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CollectionDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CollectionDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class CollectionDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class CollectionDaoTest {
 
     when(sessionMock.find(Collection.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Collection.class, id);
@@ -60,6 +61,6 @@ final class CollectionDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CollectionItemDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CollectionItemDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class CollectionItemDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -49,7 +50,7 @@ final class CollectionItemDaoTest {
     when(sessionMock.find(CollectionItem.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(CollectionItem.class, id);
@@ -61,6 +62,6 @@ final class CollectionItemDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/CollectionItemDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/CollectionItemDaoTest.java
@@ -50,7 +50,7 @@ final class CollectionItemDaoTest {
     when(sessionMock.find(CollectionItem.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(CollectionItem.class, id);
@@ -62,6 +62,6 @@ final class CollectionItemDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ContactInfoDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ContactInfoDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class ContactInfoDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class ContactInfoDaoTest {
 
     when(sessionMock.find(ContactInfo.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(ContactInfo.class, id);
@@ -60,6 +61,6 @@ final class ContactInfoDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ContactInfoDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ContactInfoDaoTest.java
@@ -49,7 +49,7 @@ final class ContactInfoDaoTest {
 
     when(sessionMock.find(ContactInfo.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(ContactInfo.class, id);
@@ -61,6 +61,6 @@ final class ContactInfoDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ExternalResourceDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ExternalResourceDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class ExternalResourceDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -49,7 +50,7 @@ final class ExternalResourceDaoTest {
     when(sessionMock.find(ExternalResource.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(ExternalResource.class, id);
@@ -61,6 +62,6 @@ final class ExternalResourceDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ExternalResourceDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ExternalResourceDaoTest.java
@@ -50,7 +50,7 @@ final class ExternalResourceDaoTest {
     when(sessionMock.find(ExternalResource.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(ExternalResource.class, id);
@@ -62,6 +62,6 @@ final class ExternalResourceDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/GameDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/GameDaoTest.java
@@ -49,7 +49,7 @@ final class GameDaoTest {
 
     when(sessionMock.find(Game.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Game.class, id);
@@ -61,6 +61,6 @@ final class GameDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/GameDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/GameDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class GameDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class GameDaoTest {
 
     when(sessionMock.find(Game.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Game.class, id);
@@ -60,6 +61,6 @@ final class GameDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/IndividualDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/IndividualDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class IndividualDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class IndividualDaoTest {
 
     when(sessionMock.find(Individual.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Individual.class, id);
@@ -60,6 +61,6 @@ final class IndividualDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/IndividualDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/IndividualDaoTest.java
@@ -49,7 +49,7 @@ final class IndividualDaoTest {
 
     when(sessionMock.find(Individual.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Individual.class, id);
@@ -61,6 +61,6 @@ final class IndividualDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/LarpSystemDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/LarpSystemDaoTest.java
@@ -49,7 +49,7 @@ final class LarpSystemDaoTest {
 
     when(sessionMock.find(LarpSystem.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(LarpSystem.class, id);
@@ -61,6 +61,6 @@ final class LarpSystemDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/LarpSystemDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/LarpSystemDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class LarpSystemDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class LarpSystemDaoTest {
 
     when(sessionMock.find(LarpSystem.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(LarpSystem.class, id);
@@ -60,6 +61,6 @@ final class LarpSystemDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/LocationDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/LocationDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class LocationDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class LocationDaoTest {
 
     when(sessionMock.find(Location.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Location.class, id);
@@ -60,6 +61,6 @@ final class LocationDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/LocationDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/LocationDaoTest.java
@@ -49,7 +49,7 @@ final class LocationDaoTest {
 
     when(sessionMock.find(Location.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Location.class, id);
@@ -61,6 +61,6 @@ final class LocationDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/RoleDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/RoleDaoTest.java
@@ -49,7 +49,7 @@ final class RoleDaoTest {
 
     when(sessionMock.find(Role.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Role.class, id);
@@ -61,6 +61,6 @@ final class RoleDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/RoleDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/RoleDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class RoleDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class RoleDaoTest {
 
     when(sessionMock.find(Role.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Role.class, id);
@@ -60,6 +61,6 @@ final class RoleDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProviderTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProviderTest.java
@@ -1,18 +1,26 @@
 package com.larpconnect.njall.data.dao;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 final class SchemaSelectionConnectionProviderTest {
 
   @Test
-  void getTenantPool_emptyOrPublicTenant_returnsSuper() {
+  void getTenantPool_invalidTenant_throwsException() {
     var provider = new SchemaSelectionConnectionProvider();
 
-    assertThat(provider.getTenantPool(null)).isNull();
-    assertThat(provider.getTenantPool("")).isNull();
-    assertThat(provider.getTenantPool("public")).isNull();
-    assertThat(provider.getTenantPool("some-tenant")).isNull();
+    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool((String) null));
+    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool(""));
+    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool("some-tenant"));
+  }
+
+  @Test
+  void getConnection_invalidTenant_throwsException() {
+    var provider = new SchemaSelectionConnectionProvider();
+
+    assertThrows(IllegalArgumentException.class, () -> provider.getConnection((String) null));
+    assertThrows(IllegalArgumentException.class, () -> provider.getConnection(""));
+    assertThrows(IllegalArgumentException.class, () -> provider.getConnection("some-tenant"));
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProviderTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProviderTest.java
@@ -7,20 +7,48 @@ import org.junit.jupiter.api.Test;
 final class SchemaSelectionConnectionProviderTest {
 
   @Test
-  void getTenantPool_invalidTenant_throwsException() {
-    var provider = new SchemaSelectionConnectionProvider();
-
-    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool((String) null));
-    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool(""));
-    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool("some-tenant"));
-  }
-
-  @Test
   void getConnection_invalidTenant_throwsException() {
     var provider = new SchemaSelectionConnectionProvider();
 
     assertThrows(IllegalArgumentException.class, () -> provider.getConnection((String) null));
     assertThrows(IllegalArgumentException.class, () -> provider.getConnection(""));
     assertThrows(IllegalArgumentException.class, () -> provider.getConnection("some-tenant"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> provider.getConnection("njall_server_a")); // length less than 3
+  }
+
+  @Test
+  void getTenantPool_invalidTenant_throwsException() {
+    var provider = new SchemaSelectionConnectionProvider();
+
+    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool((String) null));
+    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool(""));
+    assertThrows(IllegalArgumentException.class, () -> provider.getTenantPool("some-tenant"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> provider.getTenantPool("njall_server_a")); // length less than 3
+  }
+
+  @Test
+  void validateTenantId_validBaseTenants_doesNotThrow() {
+    var provider = new SchemaSelectionConnectionProvider();
+
+    // We expect UnsupportedOperationException for valid tenants since there is no pool running
+    // during tests.
+    assertThrows(UnsupportedOperationException.class, () -> provider.getTenantPool("njall_base"));
+    assertThrows(UnsupportedOperationException.class, () -> provider.getTenantPool("njall_admin"));
+    assertThrows(
+        UnsupportedOperationException.class, () -> provider.getTenantPool("njall_analytics"));
+  }
+
+  @Test
+  void validateTenantId_validServerTenant_doesNotThrow() {
+    var provider = new SchemaSelectionConnectionProvider();
+
+    // Test a valid server ID
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> provider.getTenantPool("njall_server_testserver"));
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProviderTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/SchemaSelectionConnectionProviderTest.java
@@ -1,0 +1,18 @@
+package com.larpconnect.njall.data.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class SchemaSelectionConnectionProviderTest {
+
+  @Test
+  void getTenantPool_emptyOrPublicTenant_returnsSuper() {
+    var provider = new SchemaSelectionConnectionProvider();
+
+    assertThat(provider.getTenantPool(null)).isNull();
+    assertThat(provider.getTenantPool("")).isNull();
+    assertThat(provider.getTenantPool("public")).isNull();
+    assertThat(provider.getTenantPool("some-tenant")).isNull();
+  }
+}

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ServerMetadataDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ServerMetadataDaoTest.java
@@ -50,7 +50,7 @@ final class ServerMetadataDaoTest {
     when(sessionMock.find(ServerMetadata.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(ServerMetadata.class, id);
@@ -62,6 +62,6 @@ final class ServerMetadataDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/ServerMetadataDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/ServerMetadataDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class ServerMetadataDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -49,7 +50,7 @@ final class ServerMetadataDaoTest {
     when(sessionMock.find(ServerMetadata.class, id))
         .thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(ServerMetadata.class, id);
@@ -61,6 +62,6 @@ final class ServerMetadataDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/StudioDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/StudioDaoTest.java
@@ -49,7 +49,7 @@ final class StudioDaoTest {
 
     when(sessionMock.find(Studio.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Studio.class, id);
@@ -61,6 +61,6 @@ final class StudioDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/StudioDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/StudioDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class StudioDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class StudioDaoTest {
 
     when(sessionMock.find(Studio.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(Studio.class, id);
@@ -60,6 +61,6 @@ final class StudioDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/StudioRoleDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/StudioRoleDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,10 +33,10 @@ final class StudioRoleDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -49,7 +50,7 @@ final class StudioRoleDaoTest {
 
     when(sessionMock.find(StudioRole.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(StudioRole.class, id);
@@ -61,6 +62,6 @@ final class StudioRoleDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/StudioRoleDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/StudioRoleDaoTest.java
@@ -50,7 +50,7 @@ final class StudioRoleDaoTest {
 
     when(sessionMock.find(StudioRole.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(StudioRole.class, id);
@@ -62,6 +62,6 @@ final class StudioRoleDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/TenantContextTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/TenantContextTest.java
@@ -1,0 +1,93 @@
+package com.larpconnect.njall.data.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class TenantContextTest {
+
+  private Vertx vertx;
+
+  @BeforeEach
+  void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @AfterEach
+  void tearDown() {
+    vertx.close().toCompletionStage().toCompletableFuture().join();
+  }
+
+  @Test
+  void getCurrentTenant_returnsSetTenant() throws Exception {
+    var future =
+        vertx
+            .executeBlocking(
+                () -> {
+                  TenantContext.setCurrentTenant("testserver");
+                  return TenantContext.getCurrentTenant();
+                })
+            .toCompletionStage()
+            .toCompletableFuture();
+
+    assertThat(future.get()).isEqualTo("njall_server_testserver");
+  }
+
+  @Test
+  void getCurrentTenant_noTenantSet_returnsNull() throws Exception {
+    var future =
+        vertx
+            .executeBlocking(() -> TenantContext.getCurrentTenant())
+            .toCompletionStage()
+            .toCompletableFuture();
+
+    assertThat(future.get()).isNull();
+  }
+
+  @Test
+  void clear_removesTenant() throws Exception {
+    var future =
+        vertx
+            .executeBlocking(
+                () -> {
+                  TenantContext.setCurrentTenant("testserver");
+                  TenantContext.clear();
+                  return TenantContext.getCurrentTenant();
+                })
+            .toCompletionStage()
+            .toCompletableFuture();
+
+    assertThat(future.get()).isNull();
+  }
+
+  @Test
+  void formatTenantId_empty_returnsNjallBase() {
+    assertThat(TenantContext.formatTenantId("")).isEqualTo("njall_base");
+  }
+
+  @Test
+  void formatTenantId_unprefixed_addsPrefix() {
+    assertThat(TenantContext.formatTenantId("testserver")).isEqualTo("njall_server_testserver");
+  }
+
+  @Test
+  void formatTenantId_alreadyPrefixed_returnsAsIs() {
+    assertThat(TenantContext.formatTenantId("njall_server_testserver"))
+        .isEqualTo("njall_server_testserver");
+  }
+
+  @Test
+  void formatTenantId_null_returnsNjallBase() {
+    assertThat(TenantContext.formatTenantId(null)).isEqualTo("njall_base");
+  }
+
+  @Test
+  void formatTenantId_baseTenants_returnsAsIs() {
+    assertThat(TenantContext.formatTenantId("njall_base")).isEqualTo("njall_base");
+    assertThat(TenantContext.formatTenantId("njall_admin")).isEqualTo("njall_admin");
+    assertThat(TenantContext.formatTenantId("njall_analytics")).isEqualTo("njall_analytics");
+  }
+}

--- a/data/src/test/java/com/larpconnect/njall/data/dao/TenantResolverTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/TenantResolverTest.java
@@ -1,0 +1,20 @@
+package com.larpconnect.njall.data.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class TenantResolverTest {
+
+  @Test
+  void resolveCurrentTenantIdentifier_returnsPublic() {
+    var resolver = new TenantResolver();
+    assertThat(resolver.resolveCurrentTenantIdentifier()).isEqualTo("public");
+  }
+
+  @Test
+  void validateExistingCurrentSessions_returnsFalse() {
+    var resolver = new TenantResolver();
+    assertThat(resolver.validateExistingCurrentSessions()).isFalse();
+  }
+}

--- a/data/src/test/java/com/larpconnect/njall/data/dao/TenantResolverTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/TenantResolverTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 final class TenantResolverTest {
 
   @Test
-  void resolveCurrentTenantIdentifier_returnsNjall() {
+  void resolveCurrentTenantIdentifier_returnsNjallBase() {
     var resolver = new TenantResolver();
-    assertThat(resolver.resolveCurrentTenantIdentifier()).isEqualTo("njall");
+    assertThat(resolver.resolveCurrentTenantIdentifier()).isEqualTo("njall_base");
   }
 
   @Test

--- a/data/src/test/java/com/larpconnect/njall/data/dao/TenantResolverTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/TenantResolverTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 final class TenantResolverTest {
 
   @Test
-  void resolveCurrentTenantIdentifier_returnsPublic() {
+  void resolveCurrentTenantIdentifier_returnsNjall() {
     var resolver = new TenantResolver();
-    assertThat(resolver.resolveCurrentTenantIdentifier()).isEqualTo("public");
+    assertThat(resolver.resolveCurrentTenantIdentifier()).isEqualTo("njall");
   }
 
   @Test

--- a/data/src/test/java/com/larpconnect/njall/data/dao/UserDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/UserDaoTest.java
@@ -2,6 +2,7 @@ package com.larpconnect.njall.data.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,10 @@ final class UserDaoTest {
 
     when(providerMock.get()).thenReturn(sessionFactoryMock);
 
-    when(sessionFactoryMock.withSession((Function<Mutiny.Session, Uni<Object>>) any()))
+    when(sessionFactoryMock.withSession(anyString(), (Function<Mutiny.Session, Uni<Object>>) any()))
         .thenAnswer(
             invocation -> {
-              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(0);
+              Function<Mutiny.Session, Uni<?>> function = invocation.getArgument(1);
               return function.apply(sessionMock);
             });
 
@@ -48,7 +49,7 @@ final class UserDaoTest {
 
     when(sessionMock.find(User.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById(id).await().indefinitely();
+    var actualEntity = dao.findById("test-server", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(User.class, id);
@@ -60,6 +61,6 @@ final class UserDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist(entity);
+    dao.persist("test-server", entity);
   }
 }

--- a/data/src/test/java/com/larpconnect/njall/data/dao/UserDaoTest.java
+++ b/data/src/test/java/com/larpconnect/njall/data/dao/UserDaoTest.java
@@ -49,7 +49,7 @@ final class UserDaoTest {
 
     when(sessionMock.find(User.class, id)).thenReturn(Uni.createFrom().item(expectedEntity));
 
-    var actualEntity = dao.findById("test-server", id).await().indefinitely();
+    var actualEntity = dao.findById("testserver", id).await().indefinitely();
 
     assertThat(actualEntity).isSameAs(expectedEntity);
     verify(sessionMock).find(User.class, id);
@@ -61,6 +61,6 @@ final class UserDaoTest {
 
     when(sessionMock.persist(any())).thenReturn(Uni.createFrom().voidItem());
 
-    dao.persist("test-server", entity);
+    dao.persist("testserver", entity);
   }
 }

--- a/integration/src/test/java/com/larpconnect/njall/integration/DatabaseIntegrationTest.java
+++ b/integration/src/test/java/com/larpconnect/njall/integration/DatabaseIntegrationTest.java
@@ -45,9 +45,9 @@ final class DatabaseIntegrationTest {
     resource.setData("{\"key\": \"value\"}");
     resource.setLastRefresh(OffsetDateTime.now(java.time.ZoneId.systemDefault()));
 
-    dao.persist("test-server", resource).await().indefinitely();
+    dao.persist("testserver", resource).await().indefinitely();
 
-    var fetched = dao.findById("test-server", id).await().indefinitely();
+    var fetched = dao.findById("testserver", id).await().indefinitely();
     assertThat(fetched).isNotNull();
     assertThat(fetched.getId()).isEqualTo(id);
     assertThat(fetched.getExternalUri()).isEqualTo("https://example.com");

--- a/integration/src/test/java/com/larpconnect/njall/integration/DatabaseIntegrationTest.java
+++ b/integration/src/test/java/com/larpconnect/njall/integration/DatabaseIntegrationTest.java
@@ -45,9 +45,9 @@ final class DatabaseIntegrationTest {
     resource.setData("{\"key\": \"value\"}");
     resource.setLastRefresh(OffsetDateTime.now(java.time.ZoneId.systemDefault()));
 
-    dao.persist(resource).await().indefinitely();
+    dao.persist("test-server", resource).await().indefinitely();
 
-    var fetched = dao.findById(id).await().indefinitely();
+    var fetched = dao.findById("test-server", id).await().indefinitely();
     assertThat(fetched).isNotNull();
     assertThat(fetched.getId()).isEqualTo(id);
     assertThat(fetched.getExternalUri()).isEqualTo("https://example.com");


### PR DESCRIPTION
Introduce schema-based multi-tenancy in the DAO layer by adding `serverId`
to `findById` and `persist` methods. This delegates directly to
Hibernate Reactive's multi-tenancy support via `withSession(String tenantId, ...)`
using the `serverId` to select the target schema.

Updated all respective unit tests and integration tests to use the new
signatures and Mockito configurations to intercept correctly.

Closes #277.

---
*PR created automatically by Jules for task [8500051715520521941](https://jules.google.com/task/8500051715520521941) started by @dclements*