### PR TITLE
📄 Nihiluxinator: Update gradle.md to reference JUnit 6 instead of Junit5

### DIFF
--- a/.agents/skills/gradle.md
+++ b/.agents/skills/gradle.md
@@ -54,7 +54,7 @@ These are libraries that are basically required from the start of the project.
 - Mug
 - Guava
 - Mockito in tests
-- Junit5 in tests. Do not use JUnit asserts
+- JUnit 6 in tests. Do not use JUnit asserts
 - AssertJ in tests, including the module for Guava
 - Cucumber in integration tests
 - Protobuf


### PR DESCRIPTION
💡 What was changed: Updated the `gradle.md` skills documentation to specify JUnit 6 instead of JUnit 5.
Consistency edits that were needed: No other files needed edits because `CONTRIBUTING.md`, `AGENTS.md`, and `testing.md` already correctly mentioned JUnit 6.
🎯 Why the documentation is helpful: Ensuring consistency across all agent skill files helps maintain code quality and prevents the build maintenance agent and other agents from generating tests with the wrong framework version.

---
*PR created automatically by Jules for task [16219013498051245289](https://jules.google.com/task/16219013498051245289) started by @dclements*