### PR TITLE
🚧 Pentiousinator: Centralize Testcontainers configuration in testing plugin

### DIFF
--- a/buildSrc/src/main/kotlin/larpconnect.testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/larpconnect.testing.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
     jvmArgs("-XX:+IgnoreUnrecognizedVMOptions", "--illegal-final-field-mutation=deny")
+    systemProperty("testcontainers.ryuk.disabled", "true")
     useJUnitPlatform()
     testLogging {
         events("passed", "skipped", "failed")

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -16,7 +16,3 @@ dependencies {
     testImplementation(project(":proto"))
     testImplementation(project(":server"))
 }
-
-tasks.withType<Test> {
-    systemProperty("testcontainers.ryuk.disabled", "true")
-}


### PR DESCRIPTION
💡 What was changed
Removed the `testcontainers.ryuk.disabled` system property assignment from `integration/build.gradle.kts` and moved it into the shared `larpconnect.testing` convention plugin inside `buildSrc/src/main/kotlin/larpconnect.testing.gradle.kts`. The configuration was also changed from eager configuration (`tasks.withType<Test> { ... }`) to lazy configuration (`tasks.withType<Test>().configureEach { ... }`).

🎯 Why it helps make the build system better
It reduces redundant dependency declarations and configurations across different modules. By moving this property to the shared `testing` convention plugin, any module (like `data` or `integration`) that runs tests with Testcontainers will automatically and consistently have Ryuk disabled. Additionally, converting the configuration block from eager to lazy execution aligns with Gradle best practices for faster build configuration phases.

---
*PR created automatically by Jules for task [12446561312339307566](https://jules.google.com/task/12446561312339307566) started by @dclements*