### PR TITLE
📄 Nihiluxinator: Add missing javadocs to Nodeinfo verticles

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/verticle/NodeinfoVerticle.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/NodeinfoVerticle.java
@@ -16,6 +16,13 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Verticle responsible for handling requests to the NodeInfo 2.2 endpoint.
+ *
+ * <p>This verticle responds to queries over the internal event bus for the {@code
+ * http.admin.nodeinfo.request} channel, returning standard NodeInfo data regarding the server's
+ * capabilities, usage, and software version.
+ */
 final class NodeinfoVerticle extends AbstractLcVerticle {
   private final Logger logger = LoggerFactory.getLogger(NodeinfoVerticle.class);
 

--- a/api/src/main/java/com/larpconnect/njall/api/verticle/NodeinfoWellKnownVerticle.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/NodeinfoWellKnownVerticle.java
@@ -12,6 +12,12 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Verticle handling requests to the /.well-known/nodeinfo endpoint.
+ *
+ * <p>This verticle routes incoming well-known NodeInfo requests to the appropriate NodeInfo
+ * protocol version handler (e.g., 2.2) and returns the JRD discovery document.
+ */
 final class NodeinfoWellKnownVerticle extends AbstractLcVerticle {
   private final Logger logger = LoggerFactory.getLogger(NodeinfoWellKnownVerticle.class);
 


### PR DESCRIPTION
💡 What was changed: Added missing class-level Javadoc documentation to `NodeinfoVerticle` and `NodeinfoWellKnownVerticle` in the API module.
Consistency edits that were needed: Ensured standard `<p>` tagging and clear description of handling internal event bus requests versus external HTTP requests were used.
🎯 Why the documentation is helpful: These verticles are essential for the NodeInfo federation endpoints. The added Javadocs explicitly describe *why* these classes exist and how they function at a high level.

---
*PR created automatically by Jules for task [3675964594444732697](https://jules.google.com/task/3675964594444732697) started by @dclements*