### PR TITLE
🚧 Pentiousinator: Centralize testcontainers in test module

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -13,6 +13,4 @@ dependencies {
     implementation(libs.vertx.pg.client)
 
     testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,6 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
     testImplementation(project(":api"))

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -7,8 +7,6 @@ dependencies {
     testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     api(libs.assertj.core)
     api(libs.assertj.guava)
+    api(libs.commons.compress)
     api(libs.cucumber.java)
     api(libs.junit.api)
     api(libs.junit.params)


### PR DESCRIPTION
💡 What was changed
Moved the testcontainers dependencies (testcontainers.junit.jupiter and testcontainers.postgresql) to the `test` module and exported them via `api`. Removed duplicate declarations from the `data` and `integration` modules.

🎯 Why it helps make the build system better
This centralized shared testing dependencies following the guideline to prevent duplication across individual modules, making the build system cleaner and easier to maintain.

---
*PR created automatically by Jules for task [6645500957304678562](https://jules.google.com/task/6645500957304678562) started by @dclements*