### PR TITLE
Zhongliinator: Add context annotations to ProtoCodec

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/codec/ProtoCodec.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/ProtoCodec.java
@@ -1,5 +1,6 @@
 package com.larpconnect.njall.common.codec;
 
+import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import com.larpconnect.njall.proto.MessageRequest;
 import io.vertx.core.eventbus.MessageCodec;
 
@@ -12,4 +13,5 @@ import io.vertx.core.eventbus.MessageCodec;
  * requiring the ability to serialize, deserialize, or transform protocol buffer messages has a
  * clear, type-safe dependency.
  */
+@DefaultImplementation(ProtoCodecRegistry.class)
 public interface ProtoCodec extends MessageCodec<MessageRequest, MessageRequest> {}

--- a/common/src/main/java/com/larpconnect/njall/common/codec/ProtoCodecRegistry.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/ProtoCodecRegistry.java
@@ -6,6 +6,7 @@ import static com.larpconnect.njall.common.annotations.ContractTag.PURE;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.larpconnect.njall.common.annotations.AiContract;
+import com.larpconnect.njall.common.annotations.BuildWith;
 import com.larpconnect.njall.proto.MessageRequest;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.buffer.impl.BufferImpl;
@@ -20,6 +21,7 @@ import io.vertx.core.buffer.impl.BufferImpl;
  * using protobuf rather than JSON to minimize payload size and reduce bandwidth consumption.
  */
 @Immutable
+@BuildWith(CodecModule.class)
 final class ProtoCodecRegistry implements ProtoCodec {
   private static final short VERSION = 0x01;
   private static final int INT_SIZE = 4;


### PR DESCRIPTION
💡 What was changed:
Added `@DefaultImplementation(ProtoCodecRegistry.class)` to `ProtoCodec.java`.
Added `@BuildWith(CodecModule.class)` to `ProtoCodecRegistry.java`.

🎯 Why it helps make the build system better:
Provides explicit contextual hints for agents and developers to trace the dependency graph. The interface is now clearly documented with its default implementation, and the implementation points directly to the module required to construct it, fulfilling context engineering guidelines.

---
*PR created automatically by Jules for task [2177843960141122199](https://jules.google.com/task/2177843960141122199) started by @dclements*