### PR TITLE
🚧 Pentiousinator: Centralize shared test dependencies

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -5,12 +5,15 @@ plugins {
 dependencies {
     api(libs.assertj.core)
     api(libs.assertj.guava)
+    api(libs.commons.compress)
     api(libs.cucumber.java)
     api(libs.junit.api)
     api(libs.junit.params)
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
 }


### PR DESCRIPTION
💡 What was changed
Removed duplicated declarations of `commons-compress` and `testcontainers` libraries from `data/build.gradle.kts` and `integration/build.gradle.kts`. These were added to `test/build.gradle.kts` using the `api` configuration so that any module importing `:test` inherits them automatically.

🎯 Why it helps make the build system better
It reduces redundant dependency declarations across modules, ensuring that test dependencies are consistently managed from a single central location (`:test`). This simplifies updating versions and maintaining the dependency hierarchy.

---
*PR created automatically by Jules for task [6752995165542642935](https://jules.google.com/task/6752995165542642935) started by @dclements*