### PR TITLE
📄 Nihiluxinator: Add missing Javadocs to common module packages

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/annotations/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/annotations/package-info.java
@@ -1,3 +1,4 @@
+/** Annotations that define AI contracts and guide dependency injection. */
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
 package com.larpconnect.njall.common.annotations;

--- a/common/src/main/java/com/larpconnect/njall/common/codec/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/package-info.java
@@ -1,3 +1,4 @@
+/** EventBus codecs and protobuf mapping utilities. */
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
 package com.larpconnect.njall.common.codec;

--- a/common/src/main/java/com/larpconnect/njall/common/id/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/package-info.java
@@ -1,3 +1,4 @@
+/** ID generation utilities, including UUIDv7 support. */
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
 package com.larpconnect.njall.common.id;

--- a/common/src/main/java/com/larpconnect/njall/common/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/package-info.java
@@ -1,3 +1,4 @@
+/** Common utilities and core infrastructure for the system. */
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
 package com.larpconnect.njall.common;

--- a/common/src/main/java/com/larpconnect/njall/common/time/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/time/package-info.java
@@ -1,3 +1,4 @@
+/** Time services and clocks for deterministic and monotonic time tracking. */
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
 package com.larpconnect.njall.common.time;

--- a/common/src/main/java/com/larpconnect/njall/common/verticle/package-info.java
+++ b/common/src/main/java/com/larpconnect/njall/common/verticle/package-info.java
@@ -1,3 +1,4 @@
+/** Common verticle utilities. */
 @ParametersAreNonnullByDefault
 @ReturnValuesAreNonnullByDefault
 package com.larpconnect.njall.common.verticle;


### PR DESCRIPTION
💡 **What was changed:** Added missing package-level Javadocs to the `package-info.java` files across the `common` module.

**Consistency edits that were needed:** Ensured all `package-info.java` files in the common module have a high-level summary of the package's purpose, bringing them in line with the expected documentation standards.

🎯 **Why the documentation is helpful:** It explains the *why* and a high-level abstracted view of the *how* for the core utilities (e.g., time tracking, id generation, codecs, and annotations) provided by the `common` module, improving usability for both developers and AI agents.

---
*PR created automatically by Jules for task [3604126034233563337](https://jules.google.com/task/3604126034233563337) started by @dclements*