### PR TITLE
📄 Nihiluxinator: Add Javadoc to DefaultApiObjectParser

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/DefaultApiObjectParser.java
+++ b/api/src/main/java/com/larpconnect/njall/api/DefaultApiObjectParser.java
@@ -13,6 +13,16 @@ import com.larpconnect.njall.proto.OrderedCollectionPage;
 import io.vertx.core.json.JsonObject;
 import jakarta.inject.Inject;
 
+/**
+ * Translates between generic ActivityPub JSON structures and strongly-typed Protobuf
+ * representations.
+ *
+ * <p>This parser exists to bridge the gap between the dynamic nature of ActivityPub payloads (which
+ * frequently use polymorphic arrays for 'type' and open-ended property maps) and the strict type
+ * safety required by the internal Protobuf domain models. It extracts known extensions (like Event,
+ * Link, or Document) into distinct proto fields while correctly handling polymorphic flattening
+ * during JSON serialization to ensure wire compatibility.
+ */
 @BuildWith(ApiModule.class)
 final class DefaultApiObjectParser implements ApiObjectParser {
 


### PR DESCRIPTION
💡 What was changed: Added class-level Javadoc to `DefaultApiObjectParser.java`.
Consistency edits that were needed: None required.
🎯 Why the documentation is helpful: It explains *why* the parser exists—bridging the gap between ActivityPub's dynamic JSON payload structures and LarpConnect's strict internal Protobuf domain models—rather than simply duplicating what the class does.

---
*PR created automatically by Jules for task [17338091477020711872](https://jules.google.com/task/17338091477020711872) started by @dclements*