### PR TITLE
🚧 Pentiousinator: Centralize Testcontainers in test module

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -13,6 +13,4 @@ dependencies {
     implementation(libs.vertx.pg.client)
 
     testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -7,8 +7,6 @@ dependencies {
     testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -15,4 +15,10 @@ dependencies {
     api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("Vulnerability in 1.24.0 pulled by testcontainers")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed
Centralized the `testcontainers.junit.jupiter` and `testcontainers.postgresql` dependencies by moving them to the `:test` module as `api` dependencies, and removing the redundant `testImplementation` declarations in the `:integration` and `:data` modules.

🎯 Why it helps make the build system better
Consistent dependency hierarchies are a key goal. By capturing widely shared dependencies like Testcontainers in the `:test` module, we reduce duplication across the codebase and make future updates simpler to manage.

---
*PR created automatically by Jules for task [17100528500074639410](https://jules.google.com/task/17100528500074639410) started by @dclements*