### PR TITLE
📄 Nihiluxinator: Improve Dao.java Javadoc

### DIFF
--- a/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
@@ -9,8 +9,7 @@ import io.smallrye.mutiny.Uni;
  * <p>By abstracting data access behind this interface, the business logic remains entirely
  * decoupled from the specific mechanics of Hibernate Reactive or the underlying PostgreSQL schema.
  * This separation of concerns allows for independent testing of the API layer via mocked DAOs and
- * ensures that database interactions remain consistently reactive and bounded within Mutiny {@link
- * Uni} pipelines to prevent event loop blocking.
+ * ensures that database interactions remain consistently reactive and bounded within Mutiny {@link Uni} pipelines to prevent event loop blocking.
  *
  * @param <T> The entity type
  * @param <ID> The type of the identifier

--- a/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
@@ -4,7 +4,13 @@ import com.larpconnect.njall.data.entity.DatabaseObject;
 import io.smallrye.mutiny.Uni;
 
 /**
- * Base Data Access Object interface for all database entities.
+ * Establishes a unified, non-blocking persistence contract for the application.
+ *
+ * <p>By abstracting data access behind this interface, the business logic remains entirely
+ * decoupled from the specific mechanics of Hibernate Reactive or the underlying PostgreSQL schema.
+ * This separation of concerns allows for independent testing of the API layer via mocked DAOs and
+ * ensures that database interactions remain consistently reactive and bounded within Mutiny {@link
+ * Uni} pipelines to prevent event loop blocking.
  *
  * @param <T> The entity type
  * @param <ID> The type of the identifier


### PR DESCRIPTION
💡 **What was changed**
Updated the class-level Javadoc of `Dao.java` to explain its purpose in decoupling business logic and enforcing non-blocking persistence.

**Consistency edits that were needed**
Removed arbitrary shell scripts introduced during exploration.

🎯 **Why the documentation is helpful**
It shifts the documentation from stating *what* the interface does to *why* the architectural layer exists, directly following the Nihiluxinator goals.

---
*PR created automatically by Jules for task [12098255609840430165](https://jules.google.com/task/12098255609840430165) started by @dclements*