### PR TITLE
🚧 Pentiousinator: Centralize testcontainers dependencies

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,14 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("Vulnerabilities in older versions pulled by testcontainers")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed
Moved the explicit definitions of `testcontainers-junit-jupiter` and `testcontainers-postgresql` from `integration/build.gradle.kts` and `data/build.gradle.kts` to `test/build.gradle.kts` using the `api` configuration. In addition, an explicit constraints block was added to `test/build.gradle.kts` to manage `commons-compress` dependency constraints resolving `testcontainers` related vulnerabilities. This allowed dropping explicit definitions of `commons-compress` within the `:data` and `:integration` module blocks.

🎯 Why it helps make the build system better
It reduces duplicative boilerplate. The `:test` module is universally pulled in by other modules via the standard convention plugin, meaning the dependencies naturally inherit everywhere they are expected to be evaluated without developers needing to re-define common test patterns across every new library. It explicitly adheres to the standard that shared transitive dependency vulnerabilities like `commons.compress` should be declared with `constraints` where the dependency is exported rather than declared as top level testDependencies.

---
*PR created automatically by Jules for task [16653226320405771263](https://jules.google.com/task/16653226320405771263) started by @dclements*