### PR TITLE
🚧 Pentiousinator: Centralize Testcontainers in test module

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,14 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress pulled by testcontainers")
+        }
+    }
 }


### PR DESCRIPTION
💡 **What was changed:**
- Added `testcontainers-junit-jupiter` and `testcontainers-postgresql` as `api()` dependencies in `test/build.gradle.kts`.
- Added a `constraints` block in `test/build.gradle.kts` for `commons-compress` to address vulnerabilities pulled transitively.
- Removed duplicate `testImplementation` entries for these libraries in `data/build.gradle.kts` and `integration/build.gradle.kts`.

🎯 **Why it helps make the build system better:**
Centralizes common testing dependencies and constraints, reducing duplication across modules and ensuring a single source of truth for transitive vulnerability resolutions.

---
*PR created automatically by Jules for task [7080515176626832876](https://jules.google.com/task/7080515176626832876) started by @dclements*