### PR TITLE
🚧 Pentiousinator: Centralize testcontainers and apply commons-compress constraint

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,14 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed
* Centralized `testcontainers` dependencies by moving them to the `:test` module as `api` dependencies.
* Removed redundant `testImplementation` declarations for `testcontainers` and `commons-compress` from `:data` and `:integration` modules.
* Added a `constraints` block in the `:test` module for `commons-compress` to address transitive vulnerabilities.

🎯 Why it helps make the build system better
* Reduces duplication across `build.gradle.kts` files.
* Establishes a cleaner, consistent dependency hierarchy by having common test libraries securely provided by the `:test` module.
* Addresses transitive vulnerabilities at the point of origin (in this case `:test` providing testcontainers), ensuring that all downstream consumer modules benefit from the constraint automatically without having to define it manually.

---
*PR created automatically by Jules for task [5496178448196092539](https://jules.google.com/task/5496178448196092539) started by @dclements*