### PR TITLE
📄 Nihiluxinator: Add why-focused Javadocs to ServerBindingModule and WebServerVerticle

### DIFF
--- a/server/src/main/java/com/larpconnect/njall/server/ServerBindingModule.java
+++ b/server/src/main/java/com/larpconnect/njall/server/ServerBindingModule.java
@@ -19,8 +19,8 @@ import java.util.function.Function;
  * Binds internal dependencies and configuration for the server context.
  *
  * <p>This module exists to isolate bindings that should not be directly exposed or customized by
- * external modules, ensuring that critical configurations like {@link LarpConnectConfig} and the
- * core {@link WebServerVerticle} are wired up correctly and deterministically for the application's
+ * external modules, ensuring that critical configurations like {@link LarpConnectConfig} and core
+ * components like {@link WebServerVerticle} are wired up correctly and deterministically for the application's
  * runtime.
  */
 @InstallInstead(ServerModule.class)

--- a/server/src/main/java/com/larpconnect/njall/server/ServerBindingModule.java
+++ b/server/src/main/java/com/larpconnect/njall/server/ServerBindingModule.java
@@ -15,6 +15,14 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+/**
+ * Binds internal dependencies and configuration for the server context.
+ *
+ * <p>This module exists to isolate bindings that should not be directly exposed or customized by
+ * external modules, ensuring that critical configurations like {@link LarpConnectConfig} and the
+ * core {@link WebServerVerticle} are wired up correctly and deterministically for the application's
+ * runtime.
+ */
 @InstallInstead(ServerModule.class)
 final class ServerBindingModule extends AbstractModule {
   private final Function<String, String> getenv;

--- a/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
+++ b/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
@@ -34,7 +34,15 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Web server verticle that serves OpenAPI specification. */
+/**
+ * Handles incoming HTTP traffic and routes it to the appropriate event bus destinations.
+ *
+ * <p>This verticle serves as the external boundary for the application, mapping HTTP requests
+ * (validated against an OpenAPI specification) to internal asynchronous messages. By keeping HTTP
+ * parsing and routing strictly within this verticle, the rest of the application can remain
+ * entirely agnostic of transport protocols, focusing solely on processing standard message
+ * payloads.
+ */
 @BuildWith(ServerModule.class)
 final class WebServerVerticle extends AbstractVerticle {
   private static final int DEFAULT_PORT = 8080;

--- a/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
+++ b/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handles incoming HTTP traffic and routes it to the appropriate event bus destinations.
+ * Handles incoming HTTP traffic and routes it to the appropriate event bus addresses.
  *
  * <p>This verticle serves as the external boundary for the application, mapping HTTP requests
  * (validated against an OpenAPI specification) to internal asynchronous messages. By keeping HTTP


### PR DESCRIPTION
💡 What was changed
Added class-level Javadocs to `ServerBindingModule` and `WebServerVerticle` that focus on their architectural role and reasons for existence.

Consistency edits that were needed
Ensured Javadoc formatting matches standard `<p>` tag conventions and uses `{@link}` for referenced classes.

🎯 Why the documentation is helpful
These classes lacked explanatory documentation. Adding why-focused Javadocs helps both human developers and AI agents understand the architectural boundaries (such as why `ServerBindingModule` isolates bindings and how `WebServerVerticle` acts as the external boundary for HTTP traffic), making the system's strict design much easier to navigate.

---
*PR created automatically by Jules for task [8273031248832420607](https://jules.google.com/task/8273031248832420607) started by @dclements*