### PR TITLE
Zhongliinator: Added @AiContract to Dao interface

### DIFF
--- a/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
@@ -21,8 +21,7 @@ public interface Dao<T extends DatabaseObject, ID> {
    */
   @AiContract(
       require = {"$id \\neq \\bot$"},
-      ensure = {"$res \\neq \\bot$"},
-      tags = {ContractTag.PURE},
+      tags = {ContractTag.IDEMPOTENT},
       implementationHint = "Finds an entity by its identifier.")
   Uni<T> findById(ID id);
 

--- a/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
@@ -33,7 +33,6 @@ public interface Dao<T extends DatabaseObject, ID> {
    */
   @AiContract(
       require = {"$entity \\neq \\bot$"},
-      ensure = {"$res \\neq \\bot$"},
       implementationHint = "Persists the given entity to the database.")
   Uni<Void> persist(T entity);
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
@@ -1,5 +1,7 @@
 package com.larpconnect.njall.data.dao;
 
+import com.larpconnect.njall.common.annotations.AiContract;
+import com.larpconnect.njall.common.annotations.ContractTag;
 import com.larpconnect.njall.data.entity.DatabaseObject;
 import io.smallrye.mutiny.Uni;
 
@@ -17,6 +19,11 @@ public interface Dao<T extends DatabaseObject, ID> {
    * @param id The identifier
    * @return A Uni containing the entity, or null if not found
    */
+  @AiContract(
+      require = {"$id \\neq \\bot$"},
+      ensure = {"$res \\neq \\bot$"},
+      tags = {ContractTag.PURE},
+      implementationHint = "Finds an entity by its identifier.")
   Uni<T> findById(ID id);
 
   /**
@@ -25,5 +32,9 @@ public interface Dao<T extends DatabaseObject, ID> {
    * @param entity The entity to persist
    * @return A Uni representing the completion of the persistence operation
    */
+  @AiContract(
+      require = {"$entity \\neq \\bot$"},
+      ensure = {"$res \\neq \\bot$"},
+      implementationHint = "Persists the given entity to the database.")
   Uni<Void> persist(T entity);
 }


### PR DESCRIPTION
💡 What was changed
Added `@AiContract` to `findById` and `persist` methods in the `Dao` interface.

🎯 Why it helps make the build system better
It provides explicit context on the nullability preconditions and postconditions of the methods for context-engineering.

---
*PR created automatically by Jules for task [1831875642230303963](https://jules.google.com/task/1831875642230303963) started by @dclements*