### PR TITLE
🚧 Pentiousinator: Centralize shared testing dependencies

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -13,4 +13,13 @@ dependencies {
     api(libs.mockito.junit.jupiter)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed:
Removed `testImplementation` entries for `testcontainers.junit.jupiter`, `testcontainers.postgresql`, and `commons.compress` from `data` and `integration` build configurations, replacing them with centralized `api` imports in `test/build.gradle.kts`. Also added a `constraints` block explaining the reason for pulling `commons-compress`.

🎯 Why it helps make the build system better:
This cleans up redundant dependency declarations across modules, adhering to the standard that shared testing dependencies should be centralized in `:test`. The constraints block clearly documents why the dependency exists, avoiding CI scanner warnings and making the build files cleaner and easier to maintain.

---
*PR created automatically by Jules for task [10151475945617080304](https://jules.google.com/task/10151475945617080304) started by @dclements*