### PR TITLE
🧹 Nifftyinator: CLEAN! IT! UP!

### DIFF
--- a/init/src/main/java/com/larpconnect/njall/init/BootstrapVerticleService.java
+++ b/init/src/main/java/com/larpconnect/njall/init/BootstrapVerticleService.java
@@ -38,7 +38,6 @@ final class BootstrapVerticleService extends AbstractIdleService implements Vert
   protected void startUp() {
     logger.info("Starting BootstrapVerticleService...");
 
-    // Load default config
     JsonObject defaultConfig;
     try {
       var configResource = System.getProperty("njall.config.resource", "config.json");
@@ -48,7 +47,6 @@ final class BootstrapVerticleService extends AbstractIdleService implements Vert
       throw new IllegalStateException("Failed to load default config", e);
     }
 
-    // Create temp Vertx for config loading
     var tempVertx = Vertx.vertx();
     JsonObject config;
     try {
@@ -72,16 +70,13 @@ final class BootstrapVerticleService extends AbstractIdleService implements Vert
       tempVertx.close();
     }
 
-    // Create a mutable list to add our internal modules
     var builder = ImmutableList.<Module>builder();
     builder.addAll(modules);
     builder.add(new VertxModule());
     builder.add(new ConfigModule(config));
 
-    // Create Guice Injector
     var injector = Guice.createInjector(builder.build());
 
-    // Initialize Vertx and setup service via the lifecycle instance injected
     var delegate = injector.getInstance(VerticleService.class);
     delegateRef.set(delegate);
     delegate.startAsync().awaitRunning();

--- a/integration/src/test/java/com/larpconnect/njall/integration/arch/ArchitectureTest.java
+++ b/integration/src/test/java/com/larpconnect/njall/integration/arch/ArchitectureTest.java
@@ -98,8 +98,8 @@ final class ArchitectureTest {
   public static final ArchRule loggers_should_not_be_static =
       fields().that().haveRawType(Logger.class).should().notBeStatic();
 
-  // 5. `Default<InterfaceName>` should mean that `<InterfaceName>` is annotated with
-  // `@DefaultImplementation`
+  /* 5. `Default<InterfaceName>` should mean that `<InterfaceName>` is annotated with
+   * `@DefaultImplementation` */
   @ArchTest
   public static final ArchRule default_impl_naming_convention =
       classes()
@@ -167,8 +167,8 @@ final class ArchitectureTest {
           .beAssignableTo(Module.class)
           .allowEmptyShould(true);
 
-  // 7. Dependencies must form a directed acyclic graph that mirrors the package layout.
-  // Classes in a package cannot depend on classes in any ancestor package.
+  /* 7. Dependencies must form a directed acyclic graph that mirrors the package layout.
+   * Classes in a package cannot depend on classes in any ancestor package. */
   @ArchTest
   public static final ArchRule no_dependencies_on_parent_packages =
       classes()
@@ -188,8 +188,8 @@ final class ArchitectureTest {
                             String currentPackage = item.getPackageName();
                             String targetPackage = targetClass.getPackageName();
 
-                            // Check if target package is a parent of current package
-                            // Parent package logic: current starts with target + "."
+                            /* Check if target package is a parent of current package
+                             * Parent package logic: current starts with target + "." */
                             if (currentPackage.startsWith(targetPackage + ".")) {
                               String message =
                                   String.format(

--- a/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
+++ b/server/src/main/java/com/larpconnect/njall/server/WebServerVerticle.java
@@ -17,8 +17,8 @@ import com.larpconnect.njall.proto.ProtoDef;
 import com.larpconnect.njall.proto.WebfingerResponse;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServer;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.healthchecks.HealthCheckHandler;
 import io.vertx.ext.web.openapi.router.RouterBuilder;
@@ -173,7 +173,7 @@ final class WebServerVerticle extends AbstractVerticle {
             .build();
     try {
       var json = serializer.print(message);
-      ctx.json(new JsonObject(json));
+      ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(json);
     } catch (RuntimeException | IOException e) {
       logger.error("Failed to convert message to JSON", e);
       ctx.fail(HttpURLConnection.HTTP_INTERNAL_ERROR, e);
@@ -201,7 +201,7 @@ final class WebServerVerticle extends AbstractVerticle {
                 var replyResponse = msg.body();
                 var proto = replyResponse.getProto();
                 var json = printer.print(proto.getMessage());
-                ctx.json(new JsonObject(json));
+                ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(json);
               } catch (RuntimeException | IOException e) {
                 logger.error("Failed to serialize webfinger response", e);
                 ctx.fail(HttpURLConnection.HTTP_INTERNAL_ERROR, e);
@@ -228,7 +228,7 @@ final class WebServerVerticle extends AbstractVerticle {
                 var replyResponse = msg.body();
                 var proto = replyResponse.getProto();
                 var json = printer.print(proto.getMessage());
-                ctx.json(new JsonObject(json));
+                ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(json);
               } catch (RuntimeException | IOException e) {
                 logger.error("Failed to serialize nodeinfo JRD response", e);
                 ctx.fail(HttpURLConnection.HTTP_INTERNAL_ERROR, e);
@@ -254,7 +254,7 @@ final class WebServerVerticle extends AbstractVerticle {
                 var replyResponse = msg.body();
                 var proto = replyResponse.getProto();
                 var json = printer.print(proto.getMessage());
-                ctx.json(new JsonObject(json));
+                ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(json);
               } catch (RuntimeException | IOException e) {
                 logger.error("Failed to serialize nodeinfo 2.2 response", e);
                 ctx.fail(HttpURLConnection.HTTP_INTERNAL_ERROR, e);


### PR DESCRIPTION
💡 What was changed
* Improved Vert.x serialization performance in `WebServerVerticle`
* Cleared pure cruft from `BootstrapVerticleService.java`
* Updated comment styling to multi-line block comments in `ArchitectureTest.java`

Consistency edits that were needed
* Made comments uniformly `/* */` block comments when spanning multiple lines

---
*PR created automatically by Jules for task [17704007218768887172](https://jules.google.com/task/17704007218768887172) started by @dclements*