### PR TITLE
🚧 Pentiousinator: Centralize Testcontainers in test module

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -13,4 +13,13 @@ dependencies {
     api(libs.mockito.junit.jupiter)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed:
Moved the Testcontainers JUnit Jupiter and PostgreSQL dependencies, along with the `commons-compress` dependency constraints, to the central `test` module and exported them via `api`. Removed redundant explicit dependency definitions in the `data` and `integration` modules.

🎯 Why it helps make the build system better:
Reduces code duplication across `build.gradle.kts` files and ensures consistent dependency hierarchies, ensuring all tests use identical, centrally defined Testcontainer dependencies and resolutions.

---
*PR created automatically by Jules for task [11783321244804060879](https://jules.google.com/task/11783321244804060879) started by @dclements*