### PR TITLE
🚧 Pentiousinator: Centralize testcontainers dependencies in test module

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,14 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed
Centralized the `testcontainers` and `commons-compress` dependencies into the `test` module using the `api` configuration and removed duplicate dependency declarations from the `data` and `integration` modules.

🎯 Why it helps make the build system better
It reduces duplication and keeps the build files cleaner by centralizing the testcontainers dependencies within the `test` module, taking advantage of the `api` configuration that already makes it transitively available to modules utilizing the test module. It correctly scopes `commons-compress` to a `constraints {}` block in the test module, ensuring it only forces the version update without unnecessarily adding it to the direct dependencies, aligning with Gradle's best practices.

---
*PR created automatically by Jules for task [6264784687367992662](https://jules.google.com/task/6264784687367992662) started by @dclements*