### PR TITLE
📄 Nihiluxinator: Update architecture.md module list

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,8 +11,9 @@ LarpConnect uses a multi-module Gradle build. This separation enforces strict ar
 boundaries between different parts of the system.
 
 - **Isolation of Concerns:** By splitting the project into modules like `:api`, `:common`,
-  `:server`, and `:init`, we ensure that low-level domain logic (like protocol definitions)
-  remains entirely unaware of high-level runtime mechanics (like HTTP routing).
+  `:server`, `:init`, `:parent`, `:test`, `:proto`, `:data`, `:integration`, and `:bom`, we ensure
+  that low-level domain logic (like protocol definitions) remains entirely unaware of high-level
+  runtime mechanics (like HTTP routing).
 - **Compile-Time Enforcement:** Instead of relying on discipline to avoid cyclic dependencies or
   leaking abstractions, the build system enforces these rules. If a class in `:common` tries to
   import a class from `:server`, it simply will not compile.


### PR DESCRIPTION
💡 What was changed
Updated `docs/architecture.md` to list all modules present in the project (including `:parent`, `:test`, `:proto`, `:data`, `:integration`, and `:bom`) under the "Isolation of Concerns" bullet.

Consistency edits that were needed
Aligned the `docs/architecture.md` list of modules with the full module list documented in `README.md` and the Gradle configuration.

🎯 Why the documentation is helpful
Providing a comprehensive list of modules in the architecture guide helps readers understand the full scope of architectural boundaries and separation of concerns enforced by the multi-module build.

---
*PR created automatically by Jules for task [11709426657971125348](https://jules.google.com/task/11709426657971125348) started by @dclements*