### PR TITLE
Apply Spotless formatting

### DIFF
--- a/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/Dao.java
@@ -11,7 +11,8 @@ import io.smallrye.mutiny.Uni;
  * <p>By abstracting data access behind this interface, the business logic remains entirely
  * decoupled from the specific mechanics of Hibernate Reactive or the underlying PostgreSQL schema.
  * This separation of concerns allows for independent testing of the API layer via mocked DAOs and
- * ensures that database interactions remain consistently reactive and bounded within Mutiny {@link Uni} pipelines to prevent event loop blocking.
+ * ensures that database interactions remain consistently reactive and bounded within Mutiny {@link
+ * Uni} pipelines to prevent event loop blocking.
  *
  * @param <T> The entity type
  * @param <ID> The type of the identifier

--- a/server/src/main/java/com/larpconnect/njall/server/ServerBindingModule.java
+++ b/server/src/main/java/com/larpconnect/njall/server/ServerBindingModule.java
@@ -20,8 +20,8 @@ import java.util.function.Function;
  *
  * <p>This module exists to isolate bindings that should not be directly exposed or customized by
  * external modules, ensuring that critical configurations like {@link LarpConnectConfig} and core
- * components like {@link WebServerVerticle} are wired up correctly and deterministically for the application's
- * runtime.
+ * components like {@link WebServerVerticle} are wired up correctly and deterministically for the
+ * application's runtime.
  */
 @InstallInstead(ServerModule.class)
 final class ServerBindingModule extends AbstractModule {


### PR DESCRIPTION
Applied code formatting using `./gradlew spotlessApply`. The changes include re-wrapping long javadoc comments in Java files and adding trailing newlines to several markdown files. Verified that the build and checks pass after these changes.

---
*PR created automatically by Jules for task [17781215591152102636](https://jules.google.com/task/17781215591152102636) started by @dclements*