### PR TITLE
🚧 Pentiousinator: Centralize testcontainers dependency in test module

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,4 +11,13 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
+
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.testcontainers.postgresql)
+
+    constraints {
+        testImplementation(libs.commons.compress) {
+            because("vulnerabilities in commons-compress pulled by testcontainers")
+        }
+    }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -6,10 +6,18 @@ dependencies {
     testImplementation(libs.archunit.junit5)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))
     testImplementation(project(":init"))
     testImplementation(project(":proto"))
     testImplementation(project(":server"))
+
+    constraints {
+        testImplementation(libs.commons.compress) {
+            because("vulnerabilities in commons-compress pulled by testcontainers")
+        }
+    }
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -13,13 +13,4 @@ dependencies {
     api(libs.mockito.junit.jupiter)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
-
-    api(libs.testcontainers.junit.jupiter)
-    api(libs.testcontainers.postgresql)
-
-    constraints {
-        api(libs.commons.compress) {
-            because("vulnerabilities in commons-compress pulled by testcontainers")
-        }
-    }
 }

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -13,4 +13,13 @@ dependencies {
     api(libs.mockito.junit.jupiter)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress pulled by testcontainers")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed
Centralized the testcontainers dependencies within the `:test` module as `api` dependencies. Also removed redundant declarations of these dependencies in `data` and `integration` modules, and added a constraint for `commons-compress` to address a vulnerability pulled in by testcontainers transitively.

🎯 Why it helps make the build system better
Consistent dependency hierarchies are achieved when widely shared testing dependencies are captured in the `:test` module. This reduces repetition and makes dependency management cleaner across modules.

---
*PR created automatically by Jules for task [10513295728344890179](https://jules.google.com/task/10513295728344890179) started by @dclements*