### PR TITLE
🚧 Pentiousinator: Centralize testcontainers in the test module

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,14 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed: 
- Removed `testImplementation(libs.commons.compress)`, `testImplementation(libs.testcontainers.junit.jupiter)`, and `testImplementation(libs.testcontainers.postgresql)` from `data/build.gradle.kts`.
- Removed `testImplementation(libs.commons.compress)`, `testImplementation(libs.testcontainers.junit.jupiter)`, and `testImplementation(libs.testcontainers.postgresql)` from `integration/build.gradle.kts`.
- Added `api(libs.testcontainers.junit.jupiter)` and `api(libs.testcontainers.postgresql)` to `test/build.gradle.kts`.
- Added a `constraints { api(libs.commons.compress) { because("vulnerabilities in commons-compress") } }` block in `test/build.gradle.kts` to resolve transitive dependency vulnerabilities exposed via the `api` declaration.

🎯 Why it helps make the build system better:
- Testcontainers are widely shared testing dependencies. Centralizing them in the `:test` module using `api` declarations prevents duplication across individual modules like `data` and `integration`.
- It adheres to the project's dependency hierarchy guidelines and reduces duplication in dependency declarations, keeping build files clean and consistent.
- Centralized the vulnerability override constraint logic as well to keep dependencies clean.

---
*PR created automatically by Jules for task [10188977796494295664](https://jules.google.com/task/10188977796494295664) started by @dclements*