### PR TITLE
🚧 Pentiousinator: Centralize testcontainers and commons-compress constraint

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -13,4 +13,14 @@ dependencies {
     api(libs.mockito.junit.jupiter)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
+}
+
+dependencies {
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed
Removed redundant `testcontainers` and `commons-compress` test dependency declarations from `:data` and `:integration` modules. Centralized these dependencies into the shared `:test` module utilizing `api` declarations, alongside a robust version constraints block for `commons-compress`.

🎯 Why it helps make the build system better
It reduces build configuration duplication, enforcing the "DRY" principle across Gradle files. By introducing a constraint block for `commons-compress` directly inside the module that provides it, we mitigate transitive vulnerability flags properly while propagating testing conventions cleanly downwards into all consuming modules.

---
*PR created automatically by Jules for task [14859948329868947967](https://jules.google.com/task/14859948329868947967) started by @dclements*