### PR TITLE
📄 Nihiluxinator: Improve entity Javadocs

### DIFF
--- a/data/src/main/java/com/larpconnect/njall/data/dao/RoleDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/RoleDao.java
@@ -4,6 +4,12 @@ import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import com.larpconnect.njall.data.entity.Role;
 import java.util.UUID;
 
-/** DAO for Role. */
+/**
+ * Provides data access operations for {@link Role} entities.
+ *
+ * <p>This interface abstracts the persistence mechanism, allowing the application to interact with
+ * Role data asynchronously and consistently, regardless of the underlying database schema or ORM
+ * framework implementation.
+ */
 @DefaultImplementation(DefaultRoleDao.class)
 public interface RoleDao extends Dao<Role, UUID> {}

--- a/data/src/main/java/com/larpconnect/njall/data/entity/Character.java
+++ b/data/src/main/java/com/larpconnect/njall/data/entity/Character.java
@@ -5,7 +5,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-/** Represents a character in a campaign. */
+/**
+ * Represents a character in a campaign.
+ *
+ * <p>Characters are distinct from {@link Individual} entities as they represent a fictional persona
+ * within a specific game or campaign context, rather than the physical player themselves.
+ */
 @jakarta.persistence.Entity
 @Table(name = "characters")
 @SuppressWarnings("JavaLangClash") // Intentional naming mirroring the schema

--- a/data/src/main/java/com/larpconnect/njall/data/entity/Individual.java
+++ b/data/src/main/java/com/larpconnect/njall/data/entity/Individual.java
@@ -3,7 +3,11 @@ package com.larpconnect.njall.data.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Table;
 
-/** Represents an individual person. */
+/**
+ * Represents an individual person in the system, acting as a concrete representation of a user or a
+ * real-world participant. This forms the base for specific roles like {@link User}. It is a
+ * separate entity to decouple physical identity from systemic roles.
+ */
 @jakarta.persistence.Entity
 @Table(name = "individuals")
 public class Individual extends Entity {


### PR DESCRIPTION
💡 **What was changed**
Improved the Javadocs for core domain entities (`Individual` and `Character`) and one data access interface (`RoleDao`). 

**Consistency edits that were needed**
Ensured that the documentation describes *why* the classes exist in the system's architecture rather than superficially stating *what* they are, aligning them with the documentation standards expected by the system.

🎯 **Why the documentation is helpful**
It provides critical design context for future developers (and AI agents), clarifying boundaries such as the distinction between a fictional `Character` and the physical `Individual` user, as well as the overarching purpose of abstracting persistence logic via the `Dao` pattern.

---
*PR created automatically by Jules for task [6109015540065510325](https://jules.google.com/task/6109015540065510325) started by @dclements*