### PR TITLE
📄 Nihiluxinator: Document Guice Module Rules for Agents

### DIFF
--- a/.agents/nihiluxinator/log.md
+++ b/.agents/nihiluxinator/log.md
@@ -25,3 +25,9 @@ set the `web.port` and takes precedence over `config.json` values.
 **Learning:** A PR to document incorrect JSON configuration keys (like `web.port` or `web_port`) was rejected because it is assumed developers understand basic JSON and the expected format is already specified in a protobuf. Documenting "millions of ways it could be done but that won't work" is discouraged.
 
 **Action:** When documenting configuration, focus only on how to do it correctly and rely on existing authoritative documentation (like protobufs) rather than enumerating negative examples.
+
+## 2026-04-18 - Untangling Dependencies Guice Rules
+
+**Learning:** There is a very specific, undocumented pattern regarding the rules for how Guice is set up in order to manage complexity: 'Every package can have at most one public module', 'Every package's Module is responsible for installing the modules of the subpackages', 'Dependencies may only go down or out within the package hierarchy', 'All bindings are declared explicitly and within the modules', and 'Modules may either install other modules or they can do bindings, not both'.
+
+**Action:** Ensure the 'Untangling Dependencies' rules in `docs/architecture.md` are known to agents and consider documenting them in `CONTRIBUTING.md` or `AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ modularity, your technical capabilities are partitioned into "skills":
     violations or potential bugs
 - This is a system that values correctness, completeness, and flexibility.
 - Vert.x is the base build system. Injection is handled by Guice.
+  - See the Architecture Guide for the specific Untangling Dependencies rules. Every package gets one public module, dependencies go down/out, bindings are explicit, and modules either bind or install, not both.
 
 ## Relevant Documents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ highlights include:
   Matching.
 - **Null Safety:** Use `Optional<T>` for potentially absent values. No direct
   `.get()`.
-- **Dependency Injection:** Use Guice with constructor injection.
+- **Dependency Injection:** Use Guice with constructor injection. Adhere to the "Untangling Dependencies" rules (one public module per package, downward dependencies, explicit bindings, exclusive bind or install).
 - **Testing:** JUnit 6, AssertJ, and Mockito. Follow the naming pattern:
   `<method>_<what is being tested>_<expected outcome>`.
 - **Immutability:** Prefer immutable collections and final variables.


### PR DESCRIPTION
💡 What was changed:
Added the 'Untangling Dependencies' Guice rules from the architecture guide into `AGENTS.md` and `CONTRIBUTING.md`. Also documented the finding in Nihiluxinator's log.

Consistency edits that were needed:
Ensured that both the developer contributing guide and the agent instructions are aware of the architectural constraints on Guice modules (one public module per package, downward dependencies, explicit bindings, etc).

🎯 Why the documentation is helpful:
AI agents have previously struggled to figure out where dependencies are injected or how to configure Guice modules because they were unaware of these constraints. Documenting this makes the system more legible to both human and machine developers.

---
*PR created automatically by Jules for task [5841589320580216076](https://jules.google.com/task/5841589320580216076) started by @dclements*