### PR TITLE
📄 Nihiluxinator: Add missing javadocs to Guice modules

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/ApiModule.java
+++ b/api/src/main/java/com/larpconnect/njall/api/ApiModule.java
@@ -8,6 +8,12 @@ import com.larpconnect.njall.api.verticle.ApiVerticleModule;
  * ArchUnit public class restriction which permits Modules to be public.
  */
 public final class ApiModule extends AbstractModule {
+  /**
+   * Constructs a new {@link ApiModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public ApiModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
@@ -10,6 +10,12 @@ import com.larpconnect.njall.common.time.TimeModule;
  * time services, ID generation, and EventBus codecs.
  */
 public final class CommonModule extends AbstractModule {
+  /**
+   * Constructs a new {@link CommonModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public CommonModule() {}
 
   @Override

--- a/data/src/main/java/com/larpconnect/njall/data/DataModule.java
+++ b/data/src/main/java/com/larpconnect/njall/data/DataModule.java
@@ -6,6 +6,12 @@ import com.larpconnect.njall.data.entity.EntityModule;
 
 /** Guice module for configuring data access layer dependencies. */
 public final class DataModule extends AbstractModule {
+  /**
+   * Constructs a new {@link DataModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public DataModule() {}
 
   @Override


### PR DESCRIPTION
💡 What was changed:
Added missing javadocs to the public constructors of `ApiModule`, `CommonModule`, and `DataModule`.

Consistency edits that were needed:
Ensured the added documentation followed the established pattern seen in `ServerModule` and `InitModule`—explaining *why* the constructor is public (to allow cross-package installation while encapsulating internal package-private bindings) rather than merely stating what it does.

🎯 Why the documentation is helpful:
Clarifies the architectural design choice for Guice module visibility and unifies module documentation across the codebase.

---
*PR created automatically by Jules for task [17547421169285087383](https://jules.google.com/task/17547421169285087383) started by @dclements*