### PR TITLE
Zhongliinator: Added @AiContract to StudioRoleDao and ActorEndpointDao methods

### DIFF
--- a/data/src/main/java/com/larpconnect/njall/data/dao/ActorEndpointDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/ActorEndpointDao.java
@@ -1,5 +1,7 @@
 package com.larpconnect.njall.data.dao;
 
+import com.larpconnect.njall.common.annotations.AiContract;
+import com.larpconnect.njall.common.annotations.ContractTag;
 import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import com.larpconnect.njall.data.entity.ActorEndpoint;
 import io.smallrye.mutiny.Uni;
@@ -8,7 +10,14 @@ import io.smallrye.mutiny.Uni;
 @DefaultImplementation(DefaultActorEndpointDao.class)
 public interface ActorEndpointDao {
 
+  @AiContract(
+      require = {"$id \\neq \\bot$"},
+      tags = {ContractTag.IDEMPOTENT},
+      implementationHint = "Finds an entity by its identifier.")
   Uni<ActorEndpoint> findById(ActorEndpoint.ActorEndpointId id);
 
+  @AiContract(
+      require = {"$entity \\neq \\bot$"},
+      implementationHint = "Persists the given entity to the database.")
   Uni<Void> persist(ActorEndpoint entity);
 }

--- a/data/src/main/java/com/larpconnect/njall/data/dao/StudioRoleDao.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/StudioRoleDao.java
@@ -1,5 +1,7 @@
 package com.larpconnect.njall.data.dao;
 
+import com.larpconnect.njall.common.annotations.AiContract;
+import com.larpconnect.njall.common.annotations.ContractTag;
 import com.larpconnect.njall.common.annotations.DefaultImplementation;
 import com.larpconnect.njall.data.entity.StudioRole;
 import io.smallrye.mutiny.Uni;
@@ -7,7 +9,14 @@ import io.smallrye.mutiny.Uni;
 /** DAO for StudioRole. */
 @DefaultImplementation(DefaultStudioRoleDao.class)
 public interface StudioRoleDao {
+  @AiContract(
+      require = {"$id \\neq \\bot$"},
+      tags = {ContractTag.IDEMPOTENT},
+      implementationHint = "Finds an entity by its identifier.")
   Uni<StudioRole> findById(StudioRole.StudioRoleId id);
 
+  @AiContract(
+      require = {"$entity \\neq \\bot$"},
+      implementationHint = "Persists the given entity to the database.")
   Uni<Void> persist(StudioRole entity);
 }


### PR DESCRIPTION
💡 What was changed
Added `@AiContract` annotations with appropriate `require`, `tags`, and `implementationHint` attributes to the `findById` and `persist` methods in `StudioRoleDao` and `ActorEndpointDao`.

🎯 Why it helps make the build system better
Adding these annotations ensures that the AI agents have a clear understanding of the input and behavioral contracts for these methods. Since `StudioRoleDao` and `ActorEndpointDao` don't inherit from the base `Dao` interface (due to their use of composite keys), explicitly defining these contracts maintains consistency across the data layer and improves the ease of further development for agents interacting with these DAOs.

---
*PR created automatically by Jules for task [18359155217552376918](https://jules.google.com/task/18359155217552376918) started by @dclements*