### PR TITLE
🚧 Pentiousinator: Centralize Testcontainers Dependencies

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,14 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
🚧 Pentiousinator: Centralize Testcontainers Dependencies

💡 What was changed
* Centralized `testcontainers` dependencies and a `commons-compress` vulnerability constraint into `test/build.gradle.kts`.
* Removed redundant `testcontainers` and `commons-compress` declarations from `data/build.gradle.kts` and `integration/build.gradle.kts`.

🎯 Why it helps make the build system better
* Reduces duplication across multiple module build files.
* Creates a cleaner and more consistent dependency hierarchy by ensuring tests automatically inherit standard configurations.

---
*PR created automatically by Jules for task [229270315995101836](https://jules.google.com/task/229270315995101836) started by @dclements*