### PR TITLE
📄 Nihiluxinator: Add Javadocs explaining public Guice module constructors

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/ApiModule.java
+++ b/api/src/main/java/com/larpconnect/njall/api/ApiModule.java
@@ -8,6 +8,12 @@ import com.larpconnect.njall.api.verticle.ApiVerticleModule;
  * ArchUnit public class restriction which permits Modules to be public.
  */
 public final class ApiModule extends AbstractModule {
+  /**
+   * Constructs a new {@link ApiModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public ApiModule() {}
 
   @Override

--- a/api/src/main/java/com/larpconnect/njall/api/verticle/ApiVerticleModule.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/ApiVerticleModule.java
@@ -9,6 +9,12 @@ import io.vertx.core.Verticle;
  * to bypass visibility issues.
  */
 public final class ApiVerticleModule extends AbstractModule {
+  /**
+   * Constructs a new {@link ApiVerticleModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public ApiVerticleModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
@@ -10,6 +10,12 @@ import com.larpconnect.njall.common.time.TimeModule;
  * time services, ID generation, and EventBus codecs.
  */
 public final class CommonModule extends AbstractModule {
+  /**
+   * Constructs a new {@link CommonModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public CommonModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/codec/CodecModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/CodecModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module responsible for registering Protocol Buffer codecs for the Vert.x EventBus. */
 public final class CodecModule extends AbstractModule {
+  /**
+   * Constructs a new {@link CodecModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public CodecModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/id/IdModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module responsible for providing unique identifier generation capabilities. */
 public final class IdModule extends AbstractModule {
+  /**
+   * Constructs a new {@link IdModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public IdModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/time/TimeModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/time/TimeModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module responsible for providing time-related services and monotonic clocks. */
 public final class TimeModule extends AbstractModule {
+  /**
+   * Constructs a new {@link TimeModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public TimeModule() {}
 
   @Override

--- a/data/src/main/java/com/larpconnect/njall/data/DataModule.java
+++ b/data/src/main/java/com/larpconnect/njall/data/DataModule.java
@@ -6,6 +6,12 @@ import com.larpconnect.njall.data.entity.EntityModule;
 
 /** Guice module for configuring data access layer dependencies. */
 public final class DataModule extends AbstractModule {
+  /**
+   * Constructs a new {@link DataModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public DataModule() {}
 
   @Override

--- a/data/src/main/java/com/larpconnect/njall/data/dao/DaoModule.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/DaoModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module for configuring Data Access Objects (DAOs). */
 public final class DaoModule extends AbstractModule {
+  /**
+   * Constructs a new {@link DaoModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public DaoModule() {}
 
   @Override

--- a/data/src/main/java/com/larpconnect/njall/data/entity/EntityModule.java
+++ b/data/src/main/java/com/larpconnect/njall/data/entity/EntityModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module for configuring database entities. */
 public final class EntityModule extends AbstractModule {
+  /**
+   * Constructs a new {@link EntityModule}.
+   *
+   * <p>This constructor is intentionally public to allow this module to be installed across package
+   * boundaries by other modules. It serves to encapsulate the internal package-private bindings.
+   */
   public EntityModule() {}
 
   @Override


### PR DESCRIPTION
💡 **What was changed:**
Added descriptive Javadocs to the previously empty, public constructors of multiple Guice `AbstractModule` implementations (`DataModule`, `EntityModule`, `DaoModule`, `CommonModule`, `IdModule`, `TimeModule`, `CodecModule`, `ApiModule`, and `ApiVerticleModule`).

**Consistency edits that were needed:**
The same explanatory Javadoc was applied consistently across all identified modules to ensure a unified explanation for the architectural decision behind making these constructors public.

🎯 **Why the documentation is helpful:**
It explains the *why* instead of just the *what*. Guice modules in this project have public constructors to allow them to be installed across different packages while hiding the internal bindings (which are typically package-private). This wasn't immediately obvious from looking at the empty constructors, and adding this explanation helps both human developers and AI agents better understand the system's dependency injection design.

---
*PR created automatically by Jules for task [15721671069288184064](https://jules.google.com/task/15721671069288184064) started by @dclements*