### PR TITLE
📄 Nihiluxinator: Add Javadocs explaining public visibility on Guice Modules

### DIFF
--- a/api/src/main/java/com/larpconnect/njall/api/ApiModule.java
+++ b/api/src/main/java/com/larpconnect/njall/api/ApiModule.java
@@ -8,6 +8,12 @@ import com.larpconnect.njall.api.verticle.ApiVerticleModule;
  * ArchUnit public class restriction which permits Modules to be public.
  */
 public final class ApiModule extends AbstractModule {
+  /**
+   * Constructs a new {@link ApiModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public ApiModule() {}
 
   @Override

--- a/api/src/main/java/com/larpconnect/njall/api/verticle/ApiVerticleModule.java
+++ b/api/src/main/java/com/larpconnect/njall/api/verticle/ApiVerticleModule.java
@@ -9,6 +9,12 @@ import io.vertx.core.Verticle;
  * to bypass visibility issues.
  */
 public final class ApiVerticleModule extends AbstractModule {
+  /**
+   * Constructs a new {@link ApiVerticleModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public ApiVerticleModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/CommonModule.java
@@ -10,6 +10,12 @@ import com.larpconnect.njall.common.time.TimeModule;
  * time services, ID generation, and EventBus codecs.
  */
 public final class CommonModule extends AbstractModule {
+  /**
+   * Constructs a new {@link CommonModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public CommonModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/codec/CodecModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/codec/CodecModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module responsible for registering Protocol Buffer codecs for the Vert.x EventBus. */
 public final class CodecModule extends AbstractModule {
+  /**
+   * Constructs a new {@link CodecModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public CodecModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/id/IdModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/id/IdModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module responsible for providing unique identifier generation capabilities. */
 public final class IdModule extends AbstractModule {
+  /**
+   * Constructs a new {@link IdModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public IdModule() {}
 
   @Override

--- a/common/src/main/java/com/larpconnect/njall/common/time/TimeModule.java
+++ b/common/src/main/java/com/larpconnect/njall/common/time/TimeModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module responsible for providing time-related services and monotonic clocks. */
 public final class TimeModule extends AbstractModule {
+  /**
+   * Constructs a new {@link TimeModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public TimeModule() {}
 
   @Override

--- a/data/src/main/java/com/larpconnect/njall/data/DataModule.java
+++ b/data/src/main/java/com/larpconnect/njall/data/DataModule.java
@@ -6,6 +6,12 @@ import com.larpconnect.njall.data.entity.EntityModule;
 
 /** Guice module for configuring data access layer dependencies. */
 public final class DataModule extends AbstractModule {
+  /**
+   * Constructs a new {@link DataModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public DataModule() {}
 
   @Override

--- a/data/src/main/java/com/larpconnect/njall/data/dao/DaoModule.java
+++ b/data/src/main/java/com/larpconnect/njall/data/dao/DaoModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module for configuring Data Access Objects (DAOs). */
 public final class DaoModule extends AbstractModule {
+  /**
+   * Constructs a new {@link DaoModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public DaoModule() {}
 
   @Override

--- a/data/src/main/java/com/larpconnect/njall/data/entity/EntityModule.java
+++ b/data/src/main/java/com/larpconnect/njall/data/entity/EntityModule.java
@@ -4,6 +4,12 @@ import com.google.inject.AbstractModule;
 
 /** Guice module for configuring database entities. */
 public final class EntityModule extends AbstractModule {
+  /**
+   * Constructs a new {@link EntityModule}.
+   *
+   * <p>This constructor is intentionally public to allow cross-package installation while
+   * encapsulating internal package-private bindings.
+   */
   public EntityModule() {}
 
   @Override


### PR DESCRIPTION
💡 What was changed
Added standard Javadocs to the public, no-argument constructors of various Guice `AbstractModule` implementations across the codebase (e.g., `DataModule`, `CommonModule`, `ApiModule`).

Consistency edits that were needed
Ensured the identical standard phrasing was applied across all targeted Guice module constructors to ensure uniform documentation of the project's dependency injection design patterns.

🎯 Why the documentation is helpful
The new Javadocs specifically address *why* the constructors are marked as `public` instead of just explaining *what* they are. This helps both developers and agents understand that this pattern is intentionally used to allow cross-package module installation while keeping the actual bindings encapsulated within package-private classes.

---
*PR created automatically by Jules for task [222465309607224812](https://jules.google.com/task/222465309607224812) started by @dclements*