### PR TITLE
🚧 Pentiousinator: Centralize widely shared testing dependencies

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -5,12 +5,21 @@ plugins {
 dependencies {
     api(libs.assertj.core)
     api(libs.assertj.guava)
+    api(libs.commons.compress)
     api(libs.cucumber.java)
     api(libs.junit.api)
     api(libs.junit.params)
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed
Moved testcontainers and commons-compress explicitly declared `testImplementation` dependencies from individual modules (`integration`, `data`) and centralized them into `test/build.gradle.kts` as an `api` configuration block. Added dependency constraint for `commons-compress` inside the test component to note why it is needed.

🎯 Why it helps make the build system better
It reduces redundancy across the project and ensures a standard consistent dependency hierarchy. Instead of test dependencies drifting, using `:test` uniformly handles pulling them into all downstream modules that depend on `larpconnect.testing`.

---
*PR created automatically by Jules for task [346266463780308304](https://jules.google.com/task/346266463780308304) started by @dclements*