### PR TITLE
🚧 Pentiousinator: Centralize Testcontainers dependencies and add compress constraint

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -11,8 +11,4 @@ dependencies {
     implementation(libs.mutiny.vertx.core)
     implementation(libs.mutiny.vertx.pg.client)
     implementation(libs.vertx.pg.client)
-
-    testImplementation(libs.commons.compress)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.archunit.junit5)
-    testImplementation(libs.commons.compress)
     testImplementation(libs.hibernate.core)
     testImplementation(libs.mutiny.core)
-    testImplementation(libs.testcontainers.junit.jupiter)
-    testImplementation(libs.testcontainers.postgresql)
     testImplementation(project(":api"))
     testImplementation(project(":common"))
     testImplementation(project(":data"))

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -11,6 +11,14 @@ dependencies {
     api(libs.junit.platform.suite)
     api(libs.mockito.core)
     api(libs.mockito.junit.jupiter)
+    api(libs.testcontainers.junit.jupiter)
+    api(libs.testcontainers.postgresql)
     api(libs.vertx.junit5)
     api(libs.vertx.web.client)
+
+    constraints {
+        api(libs.commons.compress) {
+            because("vulnerabilities in commons-compress")
+        }
+    }
 }


### PR DESCRIPTION
💡 What was changed:
- Centralized `testcontainers` and `commons-compress` dependencies by moving them to the `:test` module.
- Declared the dependencies as `api` in `test/build.gradle.kts` so downstream modules (like `:data` and `:integration`) can inherit them.
- Replaced the direct `testImplementation` dependency on `commons-compress` with a `constraints` block in `test/build.gradle.kts` to properly resolve the CVE vulnerability without adding the library as a direct dependency.
- Removed redundant `testImplementation` declarations for these libraries from `data/build.gradle.kts` and `integration/build.gradle.kts`.

🎯 Why it helps make the build system better:
- **Reduces duplication**: Centralizing shared test dependencies like Testcontainers eliminates the need to declare them repeatedly across multiple modules.
- **Enforces consistency**: Ensures all test modules utilize the exact same versions of Testcontainers and resolve CVEs using the same constraints.
- **Adheres to best practices**: Using a `constraints` block to address transitive vulnerabilities (like the one in `commons-compress` caused by `testcontainers`) is the idiomatic Gradle way to fix security issues without needlessly adding direct dependencies to the project.

---
*PR created automatically by Jules for task [14508767423986973933](https://jules.google.com/task/14508767423986973933) started by @dclements*