### PR TITLE
📄 Nihiluxinator: Update context engineering annotations Javadocs with architectural purpose

### DIFF
--- a/common/src/main/java/com/larpconnect/njall/common/annotations/AiContract.java
+++ b/common/src/main/java/com/larpconnect/njall/common/annotations/AiContract.java
@@ -7,7 +7,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Defines the "Logical Physics" of a method. This annotation is a Hard Invariant. */
+/**
+ * Defines the "Logical Physics" of a method or component using mathematical or logical notation.
+ *
+ * <p>This annotation acts as an ersatz form of Design by Contract. It explicitly outlines the
+ * preconditions, postconditions, and invariants of a method or class. Its primary architectural
+ * purpose is to guarantee what must be true before and after execution, thereby providing a robust
+ * context for AI agents that might otherwise struggle to trace execution flows or trust system
+ * invariants in a highly asynchronous, event-driven architecture.
+ */
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)

--- a/common/src/main/java/com/larpconnect/njall/common/annotations/BuildWith.java
+++ b/common/src/main/java/com/larpconnect/njall/common/annotations/BuildWith.java
@@ -8,7 +8,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Specifies the "Source of Truth" public Guice module for this class. */
+/**
+ * Directs automated agents to the Guice module required to instantiate a class that has a private
+ * or package-private constructor.
+ *
+ * <p>Its architectural purpose is to signal to agents that they cannot directly instantiate the
+ * target object and must instead rely on the specified Guice module to obtain it, preserving
+ * encapsulation while enabling dependency injection.
+ */
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)

--- a/common/src/main/java/com/larpconnect/njall/common/annotations/DefaultImplementation.java
+++ b/common/src/main/java/com/larpconnect/njall/common/annotations/DefaultImplementation.java
@@ -7,7 +7,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Specifies the default implementation for the annotated interface. */
+/**
+ * Indicates the expected concrete class for an interface when there is primarily a single
+ * implementation.
+ *
+ * <p>Its architectural purpose is to guide automated agents to the concrete implementation without
+ * polluting the interface with direct dependencies, ensuring that the explicit bindings defined in
+ * Guice modules remain the single source of truth while still offering discoverability during
+ * context engineering.
+ */
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)

--- a/common/src/main/java/com/larpconnect/njall/common/annotations/InstallInstead.java
+++ b/common/src/main/java/com/larpconnect/njall/common/annotations/InstallInstead.java
@@ -8,7 +8,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Signals a delegated module installation. */
+/**
+ * Signals that an automated agent should look for a binding in the specified module instead of the
+ * annotated one.
+ *
+ * <p>Its architectural purpose is to bridge the gap caused by the "one public module per package"
+ * rule. Agents often find a binding in a package-private module but become confused about how to
+ * install it. This annotation directs them to the public module that installs the package-private
+ * module, preserving the directed acyclic graph of Guice dependencies.
+ */
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
💡 **What was changed**
Replaced the brief, what-focused Javadocs on the four primary context engineering annotations (`AiContract`, `BuildWith`, `DefaultImplementation`, `InstallInstead`) with robust, architectural explanations of their purposes.

**Consistency edits that were needed**
No consistency edits were required as these annotations had not been extensively documented elsewhere, but their descriptions now align with the philosophical goals stated in `docs/architecture.md`.

🎯 **Why the documentation is helpful**
Automated agents (and human developers) frequently encounter these annotations. Explaining *why* they exist—such as avoiding Guice dependency injection pitfalls or providing hard invariants for Design by Contract—helps build better context, reducing confusion when agents navigate the multimodule architecture.

---
*PR created automatically by Jules for task [16207301180691754246](https://jules.google.com/task/16207301180691754246) started by @dclements*